### PR TITLE
Make all reset uses synchronous

### DIFF
--- a/SOUND/OPLL/VM2413/controller.vhd
+++ b/SOUND/OPLL/VM2413/controller.vhd
@@ -161,7 +161,7 @@ architecture rtl of controller is
 
 begin   -- rtl
 
-    --  ƒŒƒWƒXƒ^İ’è’l‚ğ•Û‚·‚é‚½‚ß‚Ìƒƒ‚ƒŠ
+    --  ï¿½ï¿½ï¿½Wï¿½Xï¿½^ï¿½İ’ï¿½lï¿½ï¿½Ûï¿½ï¿½ï¿½ï¿½é‚½ï¿½ß‚Ìƒï¿½ï¿½ï¿½ï¿½ï¿½
     u_register_memory : RegisterMemory
     port map (
         clk     => clk,
@@ -176,38 +176,42 @@ begin   -- rtl
         clk, reset, user_voice_wdata, user_voice_wr, user_voice_addr, slot_voice_addr,
         user_voice_rdata, slot_voice_data );
 
-    --  ƒŒƒWƒXƒ^ƒAƒhƒŒƒXƒ‰ƒbƒ` (‘æ‚PƒXƒe[ƒW)
+    --  ï¿½ï¿½ï¿½Wï¿½Xï¿½^ï¿½Aï¿½hï¿½ï¿½ï¿½Xï¿½ï¿½ï¿½bï¿½` (ï¿½ï¿½Pï¿½Xï¿½eï¿½[ï¿½W)
     process( reset, clk )
     begin
-        if( reset = '1' )then
-            regs_addr   <= (others => '0');
-        elsif( clk'event and clk = '1' )then
-            if clkena='1' then
-                if( stage = "00" )then
-                    regs_addr <= slot( 4 downto 1 );
-                else
-                    --  hold
+        if( rising_edge(clk) )then
+            if( reset = '1' )then
+                regs_addr   <= (others => '0');
+            else
+                if clkena='1' then
+                    if( stage = "00" )then
+                        regs_addr <= slot( 4 downto 1 );
+                    else
+                        --  hold
+                    end if;
                 end if;
             end if;
         end if;
     end process;
 
-    --  Œ»İ‚ÌƒXƒƒbƒg‚Ì‰¹Fƒf[ƒ^“Ç‚İo‚µƒAƒhƒŒƒXƒ‰ƒbƒ` (‘æ‚PƒXƒe[ƒW)
+    --  ï¿½ï¿½ï¿½İ‚ÌƒXï¿½ï¿½ï¿½bï¿½gï¿½Ì‰ï¿½ï¿½Fï¿½fï¿½[ï¿½^ï¿½Ç‚İoï¿½ï¿½ï¿½Aï¿½hï¿½ï¿½ï¿½Xï¿½ï¿½ï¿½bï¿½` (ï¿½ï¿½Pï¿½Xï¿½eï¿½[ï¿½W)
     process( reset, clk )
     begin
-        if( reset = '1' )then
-            slot_voice_addr <= 0;
-        elsif( clk'event and clk = '1' )then
-            if clkena='1' then
-                if( stage = "00" )then
-                    if( rflag(5) = '1' and w_channel >= "0110" )then
-                        --  ƒŠƒYƒ€ƒ‚[ƒh‚Å ch6 ˆÈ~
-                        slot_voice_addr <= conv_integer(slot) - 12 + 32;
+        if( rising_edge(clk) )then
+            if( reset = '1' )then
+                slot_voice_addr <= 0;
+            else
+                if clkena='1' then
+                    if( stage = "00" )then
+                        if( rflag(5) = '1' and w_channel >= "0110" )then
+                            --  ï¿½ï¿½ï¿½Yï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½hï¿½ï¿½ ch6 ï¿½È~
+                            slot_voice_addr <= conv_integer(slot) - 12 + 32;
+                        else
+                            slot_voice_addr <= inst_cache(conv_integer(slot)/2) * 2 + conv_integer(slot) mod 2;
+                        end if;
                     else
-                        slot_voice_addr <= inst_cache(conv_integer(slot)/2) * 2 + conv_integer(slot) mod 2;
+                        --  hold
                     end if;
-                else
-                    --  hold
                 end if;
             end if;
         end if;
@@ -232,6 +236,8 @@ begin   -- rtl
         variable vindex : voice_id_type;
 
     begin   -- process
+
+        if rising_edge(clk) then if clkena='1' then
 
         if(reset = '1') then
 
@@ -259,8 +265,8 @@ begin   -- rtl
             rhythm <= '0';
             extra_mode := '0';
             vindex := 0;
-
-        elsif clk'event and clk='1' then if clkena='1' then
+        
+        else
 
             case stage is
             --------------------------------------------------------------------------
@@ -359,16 +365,16 @@ begin   -- rtl
                         if( conv_integer(addr(3 downto 0) ) = conv_integer(slot) / 2 ) then
                             regs_tmp := regs_rdata;
                             case addr( 5 downto 4 ) is
-                                when "01" => -- 10h`18h ‚Ìê‡i‰ºˆÊ F-Numberj
+                                when "01" => -- 10hï¿½`18h ï¿½Ìê‡ï¿½iï¿½ï¿½ï¿½ï¿½ F-Numberï¿½j
                                     regs_tmp(7 downto 0) := data;               --  F-Number
                                     regs_wr <= '1';
-                                when "10" => -- 20h`28h ‚Ìê‡iSus, Key, Block, F-Number MSBj
+                                when "10" => -- 20hï¿½`28h ï¿½Ìê‡ï¿½iSus, Key, Block, F-Number MSBï¿½j
                                     regs_tmp(13) := data(5);                    --  Sus
                                     regs_tmp(12) := data(4);                    --  Key
                                     regs_tmp(11 downto 9) := data(3 downto 1);  --  Block
                                     regs_tmp(8) := data(0);                     --  F-Number
                                     regs_wr <= '1';
-                                when "11" => -- 30h`38h ‚Ìê‡iInst, Volj
+                                when "11" => -- 30hï¿½`38h ï¿½Ìê‡ï¿½iInst, Volï¿½j
                                     regs_tmp(23 downto 20) := data(7 downto 4); --  Inst
                                     regs_tmp(19 downto 16) := data(3 downto 0); --  Vol
                                     regs_wr <='1';
@@ -507,6 +513,7 @@ begin   -- rtl
             end case;
 
         end if; end if;
+        end if;
 
     end process;
 

--- a/SOUND/OPLL/VM2413/envelopememory.vhd
+++ b/SOUND/OPLL/VM2413/envelopememory.vhd
@@ -58,21 +58,24 @@ begin
 
   begin
 
-   if reset = '1' then
+  if rising_edge(clk) then
 
-     init_slot := 0;
+    if reset = '1' then
 
-   elsif clk'event and clk = '1' then
+      init_slot := 0;
 
-     if init_slot /= 18 then
-       egdata_set(init_slot) <= (others=>'1');
-       init_slot := init_slot + 1;
-     elsif wr = '1' then
-       egdata_set(conv_integer(waddr)) <= CONV_EGDATA_VECTOR(wdata);
-     end if;
-     rdata <= CONV_EGDATA(egdata_set(conv_integer(raddr)));
+    else
 
-   end if;
+      if init_slot /= 18 then
+        egdata_set(init_slot) <= (others=>'1');
+        init_slot := init_slot + 1;
+      elsif wr = '1' then
+        egdata_set(conv_integer(waddr)) <= CONV_EGDATA_VECTOR(wdata);
+      end if;
+      rdata <= CONV_EGDATA(egdata_set(conv_integer(raddr)));
+
+    end if;
+  end if;
 
 end process;
 

--- a/SOUND/OPLL/VM2413/feedbackmemory.vhd
+++ b/SOUND/OPLL/VM2413/feedbackmemory.vhd
@@ -62,25 +62,28 @@ begin
 
   begin
 
-    if reset = '1' then
+    if rising_edge(clk) then
 
-      init_ch := 0;
+      if reset = '1' then
 
-    elsif clk'event and clk='1' then
+        init_ch := 0;
 
-      if init_ch /= 9 then
+      else
 
-        data_array(init_ch) <= (others=>'0');
-        init_ch := init_ch + 1;
+        if init_ch /= 9 then
 
-      elsif wr='1' then
+          data_array(init_ch) <= (others=>'0');
+          init_ch := init_ch + 1;
 
-        data_array(waddr) <= CONV_SIGNED_LI_VECTOR(wdata);
+        elsif wr='1' then
+
+          data_array(waddr) <= CONV_SIGNED_LI_VECTOR(wdata);
+
+        end if;
+
+        rdata <= CONV_SIGNED_LI(data_array(raddr));
 
       end if;
-
-      rdata <= CONV_SIGNED_LI(data_array(raddr));
-
     end if;
 
   end process;

--- a/SOUND/OPLL/VM2413/operator.vhd
+++ b/SOUND/OPLL/VM2413/operator.vhd
@@ -52,13 +52,13 @@ entity Operator is
         FB      : in    FB_TYPE;
 
         noise   : in    std_logic;
-        pgout   : in    std_logic_vector( 17 downto 0 );    --  ®”•” 9bit, ¬”•” 9bit
+        pgout   : in    std_logic_vector( 17 downto 0 );    --  ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 9bit, ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 9bit
         egout   : in    std_logic_vector( 12 downto 0 );
 
         faddr   : out   CH_TYPE;
         fdata   : in    SIGNED_LI_TYPE;
 
-        opout   : out   std_logic_vector( 13 downto 0 )     -- ®”•” 8bit, ¬”•” 6bit
+        opout   : out   std_logic_vector( 13 downto 0 )     -- ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 8bit, ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 6bit
     );
 end Operator;
 
@@ -69,8 +69,8 @@ architecture rtl of Operator is
             clk     : in    std_logic;
             clkena  : in    std_logic;
             wf      : in    std_logic;
-            addr    : in    std_logic_vector( 17 downto 0 );    --  ®”•” 9bit, ¬”•” 9bit
-            data    : out   std_logic_vector( 13 downto 0 )     --  ®”•” 8bit, ¬”•” 6bit
+            addr    : in    std_logic_vector( 17 downto 0 );    --  ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 9bit, ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 9bit
+            data    : out   std_logic_vector( 13 downto 0 )     --  ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 8bit, ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 6bit
         );
     end component;
 
@@ -83,13 +83,13 @@ architecture rtl of Operator is
     signal ff_egout     : std_logic_vector( 12 downto 0 );
 begin
 
-    --  ƒTƒCƒ“”gi‘Î”•\Œ»j--------------------------------------------------
-    --  addr w’è‚µ‚½ŸXƒTƒCƒNƒ‹‚É data ‚ªo‚Ä‚­‚é
+    --  ï¿½Tï¿½Cï¿½ï¿½ï¿½gï¿½iï¿½Îï¿½ï¿½\ï¿½ï¿½ï¿½j--------------------------------------------------
+    --  addr ï¿½wï¿½è‚µï¿½ï¿½ï¿½ï¿½ï¿½Xï¿½Tï¿½Cï¿½Nï¿½ï¿½ï¿½ï¿½ data ï¿½ï¿½ï¿½oï¿½Ä‚ï¿½ï¿½ï¿½
     --
     --  stage   X 00    X 01    X 10    X 11    X 00
-    --  addr            X Šm’è
-    --  data                            X Šm’è
-    --  opout                                   X Šm’è
+    --  addr            X ï¿½mï¿½ï¿½
+    --  data                            X ï¿½mï¿½ï¿½
+    --  opout                                   X ï¿½mï¿½ï¿½
     --
     u_sine_table : SineTable
     port map(
@@ -108,51 +108,53 @@ begin
                         w_modula_m;
 
     process( reset, clk )
-        variable opout_buf  : std_logic_vector( 13 downto 0 );  --  ®”•” 8bit, ¬”•” 6bit
+        variable opout_buf  : std_logic_vector( 13 downto 0 );  --  ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 8bit, ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 6bit
     begin
-        if( reset = '1' )then
-            opout       <= (others => '0');
-            ff_egout    <= (others => '0');
-        elsif( clk'event and clk='1' )then
-            if( clkena = '1' )then
-                if( stage = "00" )then
-                    --  ƒTƒCƒ“”g‚ÌQÆƒAƒhƒŒƒXiˆÊ‘Šj‚ğŒˆ’è‚·‚éƒXƒe[ƒW
-                    if(    rhythm = '1' and ( slot = 14 or slot = 17 ))then -- HH or CYM
-                        addr <= (not noise) & "01111111" & "000000000";
-                    elsif( rhythm = '1' and slot = 15 )then -- SD
-                        addr <= (not pgout(pgout'high)) & "01111111" & "000000000";
-                    elsif( rhythm = '1' and slot = 16 )then -- TOM
-                        addr <= pgout;
-                    else
-                        if( fdata.sign = '0' )then      -- modula ‚Í fdata ‚Ìâ‘Î’l‚ğƒVƒtƒg‚µ‚½’l‚¾‚©‚çA‚±‚±‚Å•„†ˆ—‚µ‚Ä‚é
-                            addr <= pgout + w_modula(pgout'range);
+        if( rising_edge(clk) )then
+            if( reset = '1' )then
+                opout       <= (others => '0');
+                ff_egout    <= (others => '0');
+            else
+                if( clkena = '1' )then
+                    if( stage = "00" )then
+                        --  ï¿½Tï¿½Cï¿½ï¿½ï¿½gï¿½ÌQï¿½ÆƒAï¿½hï¿½ï¿½ï¿½Xï¿½iï¿½Ê‘ï¿½ï¿½jï¿½ï¿½ï¿½ï¿½ï¿½è‚·ï¿½ï¿½Xï¿½eï¿½[ï¿½W
+                        if(    rhythm = '1' and ( slot = 14 or slot = 17 ))then -- HH or CYM
+                            addr <= (not noise) & "01111111" & "000000000";
+                        elsif( rhythm = '1' and slot = 15 )then -- SD
+                            addr <= (not pgout(pgout'high)) & "01111111" & "000000000";
+                        elsif( rhythm = '1' and slot = 16 )then -- TOM
+                            addr <= pgout;
                         else
-                            addr <= pgout - w_modula(pgout'range);
+                            if( fdata.sign = '0' )then      -- modula ï¿½ï¿½ fdata ï¿½Ìï¿½Î’lï¿½ï¿½ï¿½Vï¿½tï¿½gï¿½ï¿½ï¿½ï¿½ï¿½lï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Aï¿½ï¿½ï¿½ï¿½ï¿½Å•ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½
+                                addr <= pgout + w_modula(pgout'range);
+                            else
+                                addr <= pgout - w_modula(pgout'range);
+                            end if;
                         end if;
-                    end if;
 
-                elsif( stage = "01" )then
-                    --  Œˆ’è‚³‚ê‚½QÆƒAƒhƒŒƒX‚ª u_sine_table ‚Ö‹Ÿ‹‹‚³‚ê‚éƒXƒe[ƒW
-                elsif( stage = "10" )then
-                    ff_egout <= egout;
+                    elsif( stage = "01" )then
+                        --  ï¿½ï¿½ï¿½è‚³ï¿½ê‚½ï¿½Qï¿½ÆƒAï¿½hï¿½ï¿½ï¿½Xï¿½ï¿½ u_sine_table ï¿½Ö‹ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Xï¿½eï¿½[ï¿½W
+                    elsif( stage = "10" )then
+                        ff_egout <= egout;
 
-                    --  ƒtƒB[ƒhƒoƒbƒNƒƒ‚ƒŠ‚ÌƒAƒhƒŒƒX‚ğŒˆ‚ß‚éƒXƒe[ƒW
-                    if( slot(0) = '1' )then
-                        if( conv_integer(slot)/2 = 8 )then
-                            faddr <= 0;
+                        --  ï¿½tï¿½Bï¿½[ï¿½hï¿½oï¿½bï¿½Nï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ÌƒAï¿½hï¿½ï¿½ï¿½Xï¿½ï¿½ï¿½ï¿½ï¿½ß‚ï¿½Xï¿½eï¿½[ï¿½W
+                        if( slot(0) = '1' )then
+                            if( conv_integer(slot)/2 = 8 )then
+                                faddr <= 0;
+                            else
+                                faddr <= conv_integer(slot)/2 + 1;  --  ï¿½ï¿½ï¿½Ìƒï¿½ï¿½Wï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½^ï¿½ÌƒAï¿½hï¿½ï¿½ï¿½Xï¿½È‚Ì‚ï¿½ +1
+                            end if;
+                        end if;
+                    elsif( stage = "11" )then
+                        -- SineTable ï¿½ï¿½ï¿½ï¿½fï¿½[ï¿½^ï¿½ï¿½ï¿½oï¿½Ä‚ï¿½ï¿½ï¿½Xï¿½eï¿½[ï¿½W
+                        if ( ( '0' & ff_egout ) + ('0'& data(12 downto 0) ) ) < "10000000000000" then
+                            opout_buf := data(13) & (ff_egout + data(12 downto 0) );
                         else
-                            faddr <= conv_integer(slot)/2 + 1;  --  Ÿ‚Ìƒ‚ƒWƒ…ƒŒ[ƒ^‚ÌƒAƒhƒŒƒX‚È‚Ì‚Å +1
+                            opout_buf := data(13) & "1111111111111";
                         end if;
+                        opout <= opout_buf;
+                        --  ï¿½ï¿½ï¿½è‚³ï¿½ê‚½ï¿½tï¿½Bï¿½[ï¿½hï¿½oï¿½bï¿½Nï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Aï¿½hï¿½ï¿½ï¿½Xï¿½ï¿½ FeedBackMemory ï¿½Ö‹ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Xï¿½eï¿½[ï¿½W
                     end if;
-                elsif( stage = "11" )then
-                    -- SineTable ‚©‚çƒf[ƒ^‚ªo‚Ä‚­‚éƒXƒe[ƒW
-                    if ( ( '0' & ff_egout ) + ('0'& data(12 downto 0) ) ) < "10000000000000" then
-                        opout_buf := data(13) & (ff_egout + data(12 downto 0) );
-                    else
-                        opout_buf := data(13) & "1111111111111";
-                    end if;
-                    opout <= opout_buf;
-                    --  Œˆ’è‚³‚ê‚½ƒtƒB[ƒhƒoƒbƒNƒƒ‚ƒŠƒAƒhƒŒƒX‚ª FeedBackMemory ‚Ö‹Ÿ‹‹‚³‚ê‚éƒXƒe[ƒW
                 end if;
             end if;
         end if;

--- a/SOUND/OPLL/VM2413/opll.vhd
+++ b/SOUND/OPLL/VM2413/opll.vhd
@@ -257,19 +257,21 @@ begin
     --  CPU�A�N�Z�X���� ------------------------------------------------------
     process( xin, reset )
     begin
-        if( reset ='1' )then
-            opllwr  <= '0';
-            opllptr <= (others =>'0');
-        elsif( xin'event and xin = '1' )then
-            if( xena = '1' )then
-                if(    cs_n = '0' and we_n = '0' and a = '0' )then
-                    --  �����W�X�^�A�h���X�w�背�W�X�^ �ւ̏�������
-                    opllptr <= d;
-                    opllwr  <= '0';
-                elsif( cs_n = '0' and we_n = '0' and a = '1' )then
-                    --  �����W�X�^ �ւ̏�������
-                    oplldat <= d;
-                    opllwr  <= '1';
+        if( rising_edge(xin) )then
+            if( reset ='1' )then
+                opllwr  <= '0';
+                opllptr <= (others =>'0');
+            else
+                if( xena = '1' )then
+                    if(    cs_n = '0' and we_n = '0' and a = '0' )then
+                        --  �����W�X�^�A�h���X�w�背�W�X�^ �ւ̏�������
+                        opllptr <= d;
+                        opllwr  <= '0';
+                    elsif( cs_n = '0' and we_n = '0' and a = '1' )then
+                        --  �����W�X�^ �ւ̏�������
+                        oplldat <= d;
+                        opllwr  <= '1';
+                    end if;
                 end if;
             end if;
         end if;

--- a/SOUND/OPLL/VM2413/outputgenerator.vhd
+++ b/SOUND/OPLL/VM2413/outputgenerator.vhd
@@ -92,7 +92,7 @@ architecture RTL of OutputGenerator is
         variable vL, vR : std_logic_vector(LI_TYPE'high + 2 downto 0);
     begin
 
-        --  •„†{â‘Î’l ¨ ‚Q‚Ì•â”
+        --  ï¿½ï¿½ï¿½ï¿½ï¿½{ï¿½ï¿½Î’l ï¿½ï¿½ ï¿½Qï¿½Ì•â”
         if( L.sign = '0' )then
             vL := "00" & L.value;
         else
@@ -106,7 +106,7 @@ architecture RTL of OutputGenerator is
 
         vL := vL + vR;
 
-        --  ‚Q‚Ì•â” ¨ •„†{â‘Î’lA‚Â‚¢‚Å‚É 1/2 ”{B‚±‚±‚Å‚PƒrƒbƒgÁŽ¸B
+        --  ï¿½Qï¿½Ì•â” ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½{ï¿½ï¿½Î’lï¿½Aï¿½Â‚ï¿½ï¿½Å‚ï¿½ 1/2 ï¿½{ï¿½Bï¿½ï¿½ï¿½ï¿½ï¿½Å‚Pï¿½rï¿½bï¿½gï¿½ï¿½ï¿½ï¿½ï¿½B
         if vL(vL'high) = '0' then -- positive
             return ( sign => '0', value => vL(vL'high-1 downto 1) );
         else -- negative
@@ -146,38 +146,40 @@ begin
     Ltbl : LinearTable port map (
         clk     => clk,
         reset   => reset,
-        addr    => opout,           --  0`127 (opout ‚Í FF ‚Ìo—Í‚¾‚©‚çƒ_ƒCƒŒƒNƒg‚É“ü‚ê‚Ä‚à–â‘è‚È‚¢j
-        data    => li_data          --  0`511
+        addr    => opout,           --  0ï¿½`127 (opout ï¿½ï¿½ FF ï¿½Ìoï¿½Í‚ï¿½ï¿½ï¿½ï¿½ï¿½_ï¿½Cï¿½ï¿½ï¿½Nï¿½gï¿½É“ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½È‚ï¿½ï¿½j
+        data    => li_data          --  0ï¿½`511
     );
 
     process( reset, clk )
     begin
-        if( reset = '1' )then
-            mo_wr <= '0';
-            fb_wr <= '0';
-        elsif( clk'event and clk = '1' )then
-            if( clkena = '1' )then
-                mo_addr <= slot;
+        if( rising_edge(clk) )then
+            if( reset = '1' )then
+                mo_wr <= '0';
+                fb_wr <= '0';
+            else
+                if( clkena = '1' )then
+                    mo_addr <= slot;
 
-                if( stage = 0 )then
-                    mo_wr   <= '0';
-                    fb_wr   <= '0';
+                    if( stage = 0 )then
+                        mo_wr   <= '0';
+                        fb_wr   <= '0';
 
-                elsif( stage = 1 )then
-                    --  opout ‚ÉŠ–]‚Ì’l‚ª“ü‚Á‚Ä‚­‚éƒXƒe[ƒW
-                elsif( stage = 2 )then
-                    --  ‘Ò‚¿
-                elsif( stage = 3 )then
-                    --  LinerTable ‚©‚ç opout ‚ÅŽw’è‚³‚ê‚½ƒAƒhƒŒƒX‚É‘Î‰ž‚·‚é’l‚ªo‚Ä‚­‚éƒXƒe[ƒW
-                    if( slot(0) = '0' )then
-                        --  ƒtƒB[ƒhƒoƒbƒNƒƒ‚ƒŠ‚É‚Íƒ‚ƒWƒ…ƒŒ[ƒ^‚Ì‚Æ‚«‚µ‚©‘‚«ž‚Ü‚È‚¢
-                        fb_addr <= conv_integer(slot)/2;
-                        fb_wdata<= AVERAGE(mo_rdata, li_data);
-                        fb_wr   <= '1';
+                    elsif( stage = 1 )then
+                        --  opout ï¿½Éï¿½ï¿½]ï¿½Ì’lï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½Xï¿½eï¿½[ï¿½W
+                    elsif( stage = 2 )then
+                        --  ï¿½Ò‚ï¿½
+                    elsif( stage = 3 )then
+                        --  LinerTable ï¿½ï¿½ï¿½ï¿½ opout ï¿½ÅŽwï¿½è‚³ï¿½ê‚½ï¿½Aï¿½hï¿½ï¿½ï¿½Xï¿½É‘Î‰ï¿½ï¿½ï¿½ï¿½ï¿½lï¿½ï¿½ï¿½oï¿½Ä‚ï¿½ï¿½ï¿½Xï¿½eï¿½[ï¿½W
+                        if( slot(0) = '0' )then
+                            --  ï¿½tï¿½Bï¿½[ï¿½hï¿½oï¿½bï¿½Nï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½É‚Íƒï¿½ï¿½Wï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½^ï¿½Ì‚Æ‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ü‚È‚ï¿½
+                            fb_addr <= conv_integer(slot)/2;
+                            fb_wdata<= AVERAGE(mo_rdata, li_data);
+                            fb_wr   <= '1';
+                        end if;
+                        -- Store raw output
+                        mo_wdata<= li_data;
+                        mo_wr   <= '1';
                     end if;
-                    -- Store raw output
-                    mo_wdata<= li_data;
-                    mo_wr   <= '1';
                 end if;
             end if;
         end if;

--- a/SOUND/OPLL/VM2413/outputmemory.vhd
+++ b/SOUND/OPLL/VM2413/outputmemory.vhd
@@ -58,26 +58,29 @@ begin
 
   begin
 
-    if (reset = '1') then
+    if rising_edge(clk) then
 
-      init_ch := 0;
+      if (reset = '1') then
 
-    elsif clk'event and clk='1' then
+        init_ch := 0;
 
-      if init_ch /= 18 then
+      else
 
-        data_array(init_ch) <= (others=>'0');
-        init_ch := init_ch + 1;
+        if init_ch /= 18 then
 
-      elsif wr='1' then
+          data_array(init_ch) <= (others=>'0');
+          init_ch := init_ch + 1;
 
-        data_array(conv_integer(addr)) <= CONV_SIGNED_LI_VECTOR(wdata);
+        elsif wr='1' then
+
+          data_array(conv_integer(addr)) <= CONV_SIGNED_LI_VECTOR(wdata);
+
+        end if;
+
+        rdata <= CONV_SIGNED_LI(data_array(conv_integer(addr)));
+        rdata2 <= CONV_SIGNED_LI(data_array(conv_integer(addr2)));
 
       end if;
-
-      rdata <= CONV_SIGNED_LI(data_array(conv_integer(addr)));
-      rdata2 <= CONV_SIGNED_LI(data_array(conv_integer(addr2)));
-
     end if;
 
   end process;

--- a/SOUND/OPLL/VM2413/phasegenerator.vhd
+++ b/SOUND/OPLL/VM2413/phasegenerator.vhd
@@ -98,8 +98,10 @@ begin
         variable dphase : PHASE_TYPE;
         variable noise14 : std_logic;
         variable noise17 : std_logic;
-        variable pgout_buf : std_logic_vector( 17 downto 0 );   --  ®”•” 9bit, ¬”•” 9bit
+        variable pgout_buf : std_logic_vector( 17 downto 0 );   --  ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 9bit, ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 9bit
   begin
+
+    if rising_edge(clk) then if clkena = '1' then
 
     if reset = '1' then
 
@@ -110,7 +112,7 @@ begin
       noise14 := '0';
       noise17 := '0';
 
-    elsif clk'event and clk='1' then if clkena = '1' then
+    else
 
       noise <= noise14 xor noise17;
 
@@ -168,6 +170,7 @@ begin
       end if;
 
     end if; end if;
+    end if;
 
   end process;
 

--- a/SOUND/OPLL/VM2413/phasememory.vhd
+++ b/SOUND/OPLL/VM2413/phasememory.vhd
@@ -57,11 +57,13 @@ begin
 
   begin
 
+   if rising_edge(clk) then
+
    if reset = '1' then
 
       init_slot := 0;
 
-   elsif clk'event and clk = '1' then
+   else
 
      if init_slot /= 18 then
 
@@ -77,6 +79,7 @@ begin
      memout <= phase_array(conv_integer(slot));
 
     end if;
+   end if;
 
   end process;
 

--- a/SOUND/OPLL/VM2413/registermemory.vhd
+++ b/SOUND/OPLL/VM2413/registermemory.vhd
@@ -49,7 +49,7 @@ entity RegisterMemory is
 end RegisterMemory;
 
 architecture rtl of registermemory is
-    --  ƒ`ƒƒƒlƒ‹î•ñ•Û—p 1read/1write ‚Ì SRAM
+    --  ï¿½`ï¿½ï¿½ï¿½lï¿½ï¿½ï¿½ï¿½ï¿½Ûï¿½ï¿½p 1read/1write ï¿½ï¿½ SRAM
     type regs_array_type is array (0 to 8) of std_logic_vector( 23 downto 0 );
     signal regs_array : regs_array_type;
 
@@ -57,19 +57,21 @@ begin
     process( reset, clk )
         variable init_state : integer range 0 to 9;
     begin
-        if( reset = '1' )then
-            init_state := 0;
-        elsif( clk'event and clk ='1' )then
-            if( init_state /= 9 )then
-                --  ‹N“®‚µ‚Ä‚·‚®‚É RAM ‚Ì“à—e‚ğ‰Šú‰»‚·‚é
-                regs_array( init_state ) <= (others => '0');
-                init_state := init_state + 1;
-            elsif( wr = '1' )then
-                --  ‘‚«‚İƒTƒCƒNƒ‹
-                regs_array( conv_integer(addr) ) <= idata;
+        if( rising_edge(clk) )then
+            if( reset = '1' )then
+                init_state := 0;
+            else
+                if( init_state /= 9 )then
+                    --  ï¿½Nï¿½ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½ï¿½ï¿½ RAM ï¿½Ì“ï¿½ï¿½eï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+                    regs_array( init_state ) <= (others => '0');
+                    init_state := init_state + 1;
+                elsif( wr = '1' )then
+                    --  ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½İƒTï¿½Cï¿½Nï¿½ï¿½
+                    regs_array( conv_integer(addr) ) <= idata;
+                end if;
+                --  ï¿½Ç‚İoï¿½ï¿½ï¿½Íí
+                odata <= regs_array( conv_integer(addr) );
             end if;
-            --  “Ç‚İo‚µ‚Íí
-            odata <= regs_array( conv_integer(addr) );
         end if;
     end process;
 end rtl;

--- a/SOUND/OPLL/VM2413/slotcounter.vhd
+++ b/SOUND/OPLL/VM2413/slotcounter.vhd
@@ -57,19 +57,21 @@ begin
 
     process( reset, clk )
     begin
-        if( reset = '1' )then
-            ff_count <= "1000111" - delay;
-        elsif( clk'event and clk='1' )then
-            if( clkena ='1' )then
-                if( ff_count = "1000111" )then      -- 71
-                    ff_count <= (others => '0');
-                else
-                    ff_count <= ff_count + 1;
+        if( rising_edge(clk) )then
+            if( reset = '1' )then
+                ff_count <= "1000111" - delay;
+            else
+                if( clkena ='1' )then
+                    if( ff_count = "1000111" )then      -- 71
+                        ff_count <= (others => '0');
+                    else
+                        ff_count <= ff_count + 1;
+                    end if;
                 end if;
             end if;
         end if;
     end process;
 
-    stage   <= ff_count( 1 downto 0 );      --  0`3 ‚ÅzŠÂ
-    slot    <= ff_count( 6 downto 2 );      --  0`17 ‚ÅzŠÂ
+    stage   <= ff_count( 1 downto 0 );      --  0ï¿½`3 ï¿½Åzï¿½ï¿½
+    slot    <= ff_count( 6 downto 2 );      --  0ï¿½`17 ï¿½Åzï¿½ï¿½
 end rtl;

--- a/SOUND/OPLL/VM2413/temporalmixer.vhd
+++ b/SOUND/OPLL/VM2413/temporalmixer.vhd
@@ -62,14 +62,16 @@ begin
   process (clk, reset)
   begin
 
+    if rising_edge(clk) then if clkena='1' then
+
     if reset = '1' then
 
       maddr  <= (others => '0');
       mute   <= '1';
-		mix    <= (others =>'0');
-		mixout <= (others =>'0');
+      mix    <= (others =>'0');
+      mixout <= (others =>'0');
 
-    elsif clk'event and clk = '1' then if clkena='1' then
+    else
 
       if stage = 0 then
 
@@ -142,6 +144,7 @@ begin
       end if;
 
     end if; end if;
+    end if;
 
   end process;
 

--- a/SOUND/OPLL/VM2413/voicememory.vhd
+++ b/SOUND/OPLL/VM2413/voicememory.vhd
@@ -75,34 +75,37 @@ begin
 
   begin
 
-    if reset = '1' then
+    if rising_edge(clk) then
 
-      init_id := 0;
-      rstate <= 0;
+      if reset = '1' then
 
-    elsif clk'event and clk = '1' then
+        init_id := 0;
+        rstate <= 0;
 
-      if init_id /= VOICE_ID_TYPE'high+1 then
+      else
 
-        case rstate is
-        when 0 =>
-          rom_addr <= init_id;
-          rstate <= 1;
-        when 1 =>
-          rstate <= 2;
-        when 2 =>
-          voices(init_id) <= CONV_VOICE_VECTOR(rom_data);
-          rstate <= 0;
-          init_id := init_id + 1;
-        end case;
+        if init_id /= VOICE_ID_TYPE'high+1 then
 
-      elsif wr = '1' then
-        voices(rwaddr) <= CONV_VOICE_VECTOR(idata);
+          case rstate is
+          when 0 =>
+            rom_addr <= init_id;
+            rstate <= 1;
+          when 1 =>
+            rstate <= 2;
+          when 2 =>
+            voices(init_id) <= CONV_VOICE_VECTOR(rom_data);
+            rstate <= 0;
+            init_id := init_id + 1;
+          end case;
+
+        elsif wr = '1' then
+          voices(rwaddr) <= CONV_VOICE_VECTOR(idata);
+        end if;
+
+        odata <= CONV_VOICE(voices(rwaddr));
+        rodata <= CONV_VOICE(voices(roaddr));
+
       end if;
-
-      odata <= CONV_VOICE(voices(rwaddr));
-      rodata <= CONV_VOICE(voices(roaddr));
-
     end if;
 
   end process;

--- a/SOUND/OPLL/eseopll.vhd
+++ b/SOUND/OPLL/eseopll.vhd
@@ -75,41 +75,44 @@ begin
 
   begin
 
-    if reset = '1' then
+    if rising_edge(clk21m) then
 
-      counter <= 0;
+      if reset = '1' then
 
-    elsif clk21m'event and clk21m = '1' then
+        counter <= 0;
 
-      if counter /= 0 then
-        counter <= counter - 1;
-        ack <= '0';
       else
-        if req = '1' then
-          if enawait = '1' then
-            if adr(0) = '0' then
-              counter <= 4*6;
-            else
-              counter <= 72*6;
+
+        if counter /= 0 then
+          counter <= counter - 1;
+          ack <= '0';
+        else
+          if req = '1' then
+            if enawait = '1' then
+              if adr(0) = '0' then
+                counter <= 4*6;
+              else
+                counter <= 72*6;
+              end if;
             end if;
+            A_buf <= adr(0);
+            dbo_buf <= dbo;
+            CS_n_buf <= not req;
+            WE_n_buf <= not wrt;
           end if;
-          A_buf <= adr(0);
-          dbo_buf <= dbo;
-          CS_n_buf <= not req;
-          WE_n_buf <= not wrt;
+          ack <= req;
         end if;
-        ack <= req;
+
+        if (clkena = '1') then
+
+          A    <= A_buf;
+          D    <= dbo_buf;
+          CS_n <= CS_n_buf;
+          WE_n <= WE_n_buf;
+
+        end if;
+
       end if;
-
-      if (clkena = '1') then
-
-        A    <= A_buf;
-        D    <= dbo_buf;
-        CS_n <= CS_n_buf;
-        WE_n <= WE_n_buf;
-
-      end if;
-
     end if;
 
   end process;

--- a/SOUND/SCC/scc_wave.vhd
+++ b/SOUND/SCC/scc_wave.vhd
@@ -38,9 +38,9 @@ library ieee;
 
 entity scc_wave_mul is
     port(
-        a           : in    std_logic_vector(  7 downto 0 );    -- 8bit ÇQÇÃï‚êî
-        b           : in    std_logic_vector(  3 downto 0 );    -- 4bit ÉoÉCÉiÉä
-        c           : out   std_logic_vector( 11 downto 0 )     -- 12bit ÇQÇÃï‚êî
+        a           : in    std_logic_vector(  7 downto 0 );    -- 8bit ÔøΩQÔøΩÃï‚êî
+        b           : in    std_logic_vector(  3 downto 0 );    -- 4bit ÔøΩoÔøΩCÔøΩiÔøΩÔøΩ
+        c           : out   std_logic_vector( 11 downto 0 )     -- 12bit ÔøΩQÔøΩÃï‚êî
     );
 end scc_wave_mul;
 
@@ -58,9 +58,9 @@ library ieee;
 
 entity scc_mix_mul is
     port(
-        a           : in    std_logic_vector( 15 downto 0 );    -- 16bit ÇQÇÃï‚êî
-        b           : in    std_logic_vector(  2 downto 0 );    -- 3bit ÉoÉCÉiÉä
-        c           : out   std_logic_vector( 18 downto 0 )     -- 19bit ÇQÇÃï‚êî
+        a           : in    std_logic_vector( 15 downto 0 );    -- 16bit ÔøΩQÔøΩÃï‚êî
+        b           : in    std_logic_vector(  2 downto 0 );    -- 3bit ÔøΩoÔøΩCÔøΩiÔøΩÔøΩ
+        c           : out   std_logic_vector( 18 downto 0 )     -- 19bit ÔøΩQÔøΩÃï‚êî
     );
 end scc_mix_mul;
 
@@ -105,9 +105,9 @@ architecture rtl of scc_wave is
 
     component scc_wave_mul
         port(
-            a   : in    std_logic_vector(  7 downto 0 );    -- 8bit ÇQÇÃï‚êî
-            b   : in    std_logic_vector(  3 downto 0 );    -- 4bit ÉoÉCÉiÉä
-            c   : out   std_logic_vector( 11 downto 0 )     -- 12bit ÇQÇÃï‚êî
+            a   : in    std_logic_vector(  7 downto 0 );    -- 8bit ÔøΩQÔøΩÃï‚êî
+            b   : in    std_logic_vector(  3 downto 0 );    -- 4bit ÔøΩoÔøΩCÔøΩiÔøΩÔøΩ
+            c   : out   std_logic_vector( 11 downto 0 )     -- 12bit ÔøΩQÔøΩÃï‚êî
         );
     end component;
 
@@ -166,65 +166,69 @@ begin
     ----------------------------------------------------------------
     process(clk21m, reset)
     begin
-        if( reset = '1' )then
-            ff_req_dl       <= '0';
+        if (rising_edge(clk21m)) then
 
-            reg_freq_ch_a   <= (others => '0');
-            reg_freq_ch_b   <= (others => '0');
-            reg_freq_ch_c   <= (others => '0');
-            reg_freq_ch_d   <= (others => '0');
-            reg_freq_ch_e   <= (others => '0');
+            if( reset = '1' )then
+                ff_req_dl       <= '0';
 
-            reg_vol_ch_a    <= (others => '0');
-            reg_vol_ch_b    <= (others => '0');
-            reg_vol_ch_c    <= (others => '0');
-            reg_vol_ch_d    <= (others => '0');
-            reg_vol_ch_e    <= (others => '0');
+                reg_freq_ch_a   <= (others => '0');
+                reg_freq_ch_b   <= (others => '0');
+                reg_freq_ch_c   <= (others => '0');
+                reg_freq_ch_d   <= (others => '0');
+                reg_freq_ch_e   <= (others => '0');
 
-            reg_ch_sel      <= (others => '0');
-            reg_mode_sel    <= (others => '0');
+                reg_vol_ch_a    <= (others => '0');
+                reg_vol_ch_b    <= (others => '0');
+                reg_vol_ch_c    <= (others => '0');
+                reg_vol_ch_d    <= (others => '0');
+                reg_vol_ch_e    <= (others => '0');
 
-            ff_rst_ch_a     <= '0';
-            ff_rst_ch_b     <= '0';
-            ff_rst_ch_c     <= '0';
-            ff_rst_ch_d     <= '0';
-            ff_rst_ch_e     <= '0';
+                reg_ch_sel      <= (others => '0');
+                reg_mode_sel    <= (others => '0');
 
-        elsif (clk21m'event and clk21m = '1') then
-            -- mapped i/o port access on b8a0-b8afh (9880-988fh) ... register write
-            if( req = '1' and ff_req_dl = '0' and adr(7 downto 5) = "101" and wrt = '1' )then
-                case adr(3 downto 0) is
-                    when "0000" => reg_freq_ch_a(  7 downto 0 ) <= dbo( 7 downto 0 ); ff_rst_ch_a <= reg_mode_sel(5);
-                    when "0001" => reg_freq_ch_a( 11 downto 8 ) <= dbo( 3 downto 0 ); ff_rst_ch_a <= reg_mode_sel(5);
-                    when "0010" => reg_freq_ch_b(  7 downto 0 ) <= dbo( 7 downto 0 ); ff_rst_ch_b <= reg_mode_sel(5);
-                    when "0011" => reg_freq_ch_b( 11 downto 8 ) <= dbo( 3 downto 0 ); ff_rst_ch_b <= reg_mode_sel(5);
-                    when "0100" => reg_freq_ch_c(  7 downto 0 ) <= dbo( 7 downto 0 ); ff_rst_ch_c <= reg_mode_sel(5);
-                    when "0101" => reg_freq_ch_c( 11 downto 8 ) <= dbo( 3 downto 0 ); ff_rst_ch_c <= reg_mode_sel(5);
-                    when "0110" => reg_freq_ch_d(  7 downto 0 ) <= dbo( 7 downto 0 ); ff_rst_ch_d <= reg_mode_sel(5);
-                    when "0111" => reg_freq_ch_d( 11 downto 8 ) <= dbo( 3 downto 0 ); ff_rst_ch_d <= reg_mode_sel(5);
-                    when "1000" => reg_freq_ch_e(  7 downto 0 ) <= dbo( 7 downto 0 ); ff_rst_ch_e <= reg_mode_sel(5);
-                    when "1001" => reg_freq_ch_e( 11 downto 8 ) <= dbo( 3 downto 0 ); ff_rst_ch_e <= reg_mode_sel(5);
-                    when "1010" => reg_vol_ch_a( 3 downto 0 )   <= dbo( 3 downto 0 );
-                    when "1011" => reg_vol_ch_b( 3 downto 0 )   <= dbo( 3 downto 0 );
-                    when "1100" => reg_vol_ch_c( 3 downto 0 )   <= dbo( 3 downto 0 );
-                    when "1101" => reg_vol_ch_d( 3 downto 0 )   <= dbo( 3 downto 0 );
-                    when "1110" => reg_vol_ch_e( 3 downto 0 )   <= dbo( 3 downto 0 );
-                    when others => reg_ch_sel(   4 downto 0 )   <= dbo( 4 downto 0 );
-                end case;
-            elsif (clkena = '1') then
-                ff_rst_ch_a <= '0';
-                ff_rst_ch_b <= '0';
-                ff_rst_ch_c <= '0';
-                ff_rst_ch_d <= '0';
-                ff_rst_ch_e <= '0';
+                ff_rst_ch_a     <= '0';
+                ff_rst_ch_b     <= '0';
+                ff_rst_ch_c     <= '0';
+                ff_rst_ch_d     <= '0';
+                ff_rst_ch_e     <= '0';
+
+            else
+
+                -- mapped i/o port access on b8a0-b8afh (9880-988fh) ... register write
+                if( req = '1' and ff_req_dl = '0' and adr(7 downto 5) = "101" and wrt = '1' )then
+                    case adr(3 downto 0) is
+                        when "0000" => reg_freq_ch_a(  7 downto 0 ) <= dbo( 7 downto 0 ); ff_rst_ch_a <= reg_mode_sel(5);
+                        when "0001" => reg_freq_ch_a( 11 downto 8 ) <= dbo( 3 downto 0 ); ff_rst_ch_a <= reg_mode_sel(5);
+                        when "0010" => reg_freq_ch_b(  7 downto 0 ) <= dbo( 7 downto 0 ); ff_rst_ch_b <= reg_mode_sel(5);
+                        when "0011" => reg_freq_ch_b( 11 downto 8 ) <= dbo( 3 downto 0 ); ff_rst_ch_b <= reg_mode_sel(5);
+                        when "0100" => reg_freq_ch_c(  7 downto 0 ) <= dbo( 7 downto 0 ); ff_rst_ch_c <= reg_mode_sel(5);
+                        when "0101" => reg_freq_ch_c( 11 downto 8 ) <= dbo( 3 downto 0 ); ff_rst_ch_c <= reg_mode_sel(5);
+                        when "0110" => reg_freq_ch_d(  7 downto 0 ) <= dbo( 7 downto 0 ); ff_rst_ch_d <= reg_mode_sel(5);
+                        when "0111" => reg_freq_ch_d( 11 downto 8 ) <= dbo( 3 downto 0 ); ff_rst_ch_d <= reg_mode_sel(5);
+                        when "1000" => reg_freq_ch_e(  7 downto 0 ) <= dbo( 7 downto 0 ); ff_rst_ch_e <= reg_mode_sel(5);
+                        when "1001" => reg_freq_ch_e( 11 downto 8 ) <= dbo( 3 downto 0 ); ff_rst_ch_e <= reg_mode_sel(5);
+                        when "1010" => reg_vol_ch_a( 3 downto 0 )   <= dbo( 3 downto 0 );
+                        when "1011" => reg_vol_ch_b( 3 downto 0 )   <= dbo( 3 downto 0 );
+                        when "1100" => reg_vol_ch_c( 3 downto 0 )   <= dbo( 3 downto 0 );
+                        when "1101" => reg_vol_ch_d( 3 downto 0 )   <= dbo( 3 downto 0 );
+                        when "1110" => reg_vol_ch_e( 3 downto 0 )   <= dbo( 3 downto 0 );
+                        when others => reg_ch_sel(   4 downto 0 )   <= dbo( 4 downto 0 );
+                    end case;
+                elsif (clkena = '1') then
+                    ff_rst_ch_a <= '0';
+                    ff_rst_ch_b <= '0';
+                    ff_rst_ch_c <= '0';
+                    ff_rst_ch_d <= '0';
+                    ff_rst_ch_e <= '0';
+                end if;
+
+                -- mapped i/o port access on b8c0-b8dfh (98e0-98ffh) ... register write
+                if( req = '1' and wrt = '1' and adr(7 downto 5) = "110" )then
+                    reg_mode_sel <= dbo;
+                end if;
+
+                ff_req_dl <= req;
             end if;
-
-            -- mapped i/o port access on b8c0-b8dfh (98e0-98ffh) ... register write
-            if( req = '1' and wrt = '1' and adr(7 downto 5) = "110" )then
-                reg_mode_sel <= dbo;
-            end if;
-
-            ff_req_dl <= req;
         end if;
     end process;
 
@@ -243,71 +247,73 @@ begin
         variable ff_cnt_ch_d : std_logic_vector( 11 downto 0 );
         variable ff_cnt_ch_e : std_logic_vector( 11 downto 0 );
     begin
-        if (reset = '1') then
-            ff_cnt_ch_a := (others => '0');
-            ff_cnt_ch_b := (others => '0');
-            ff_cnt_ch_c := (others => '0');
-            ff_cnt_ch_d := (others => '0');
-            ff_cnt_ch_e := (others => '0');
+        if (rising_edge(clk21m)) then
+            if (reset = '1') then
+                ff_cnt_ch_a := (others => '0');
+                ff_cnt_ch_b := (others => '0');
+                ff_cnt_ch_c := (others => '0');
+                ff_cnt_ch_d := (others => '0');
+                ff_cnt_ch_e := (others => '0');
 
-            ff_ptr_ch_a <= (others => '0');
-            ff_ptr_ch_b <= (others => '0');
-            ff_ptr_ch_c <= (others => '0');
-            ff_ptr_ch_d <= (others => '0');
-            ff_ptr_ch_e <= (others => '0');
-        elsif (clk21m'event and clk21m = '1') then
-            if (clkena = '1') then
+                ff_ptr_ch_a <= (others => '0');
+                ff_ptr_ch_b <= (others => '0');
+                ff_ptr_ch_c <= (others => '0');
+                ff_ptr_ch_d <= (others => '0');
+                ff_ptr_ch_e <= (others => '0');
+            else
+                if (clkena = '1') then
 
-                if (reg_freq_ch_a(11 downto 3) = "000000000" or ff_rst_ch_a = '1') then
-                    ff_ptr_ch_a <= "00000";
-                    ff_cnt_ch_a := reg_freq_ch_a;
-                elsif (ff_cnt_ch_a = x"000") then
-                    ff_ptr_ch_a <= ff_ptr_ch_a + 1;
-                    ff_cnt_ch_a := reg_freq_ch_a;
-                else
-                    ff_cnt_ch_a := ff_cnt_ch_a - 1;
+                    if (reg_freq_ch_a(11 downto 3) = "000000000" or ff_rst_ch_a = '1') then
+                        ff_ptr_ch_a <= "00000";
+                        ff_cnt_ch_a := reg_freq_ch_a;
+                    elsif (ff_cnt_ch_a = x"000") then
+                        ff_ptr_ch_a <= ff_ptr_ch_a + 1;
+                        ff_cnt_ch_a := reg_freq_ch_a;
+                    else
+                        ff_cnt_ch_a := ff_cnt_ch_a - 1;
+                    end if;
+
+                    if (reg_freq_ch_b(11 downto 3) = "000000000" or ff_rst_ch_b = '1') then
+                        ff_ptr_ch_b <= "00000";
+                        ff_cnt_ch_b := reg_freq_ch_b;
+                    elsif (ff_cnt_ch_b = x"000") then
+                        ff_ptr_ch_b <= ff_ptr_ch_b + 1;
+                        ff_cnt_ch_b := reg_freq_ch_b;
+                    else
+                        ff_cnt_ch_b := ff_cnt_ch_b - 1;
+                    end if;
+
+                    if (reg_freq_ch_c(11 downto 3) = "000000000" or ff_rst_ch_c = '1') then
+                        ff_ptr_ch_c <= "00000";
+                        ff_cnt_ch_c := reg_freq_ch_c;
+                    elsif (ff_cnt_ch_c = x"000") then
+                        ff_ptr_ch_c <= ff_ptr_ch_c + 1;
+                        ff_cnt_ch_c := reg_freq_ch_c;
+                    else
+                        ff_cnt_ch_c := ff_cnt_ch_c - 1;
+                    end if;
+
+                    if (reg_freq_ch_d(11 downto 3) = "000000000" or ff_rst_ch_d = '1') then
+                        ff_ptr_ch_d <= "00000";
+                        ff_cnt_ch_d := reg_freq_ch_d;
+                    elsif (ff_cnt_ch_d = x"000") then
+                        ff_ptr_ch_d <= ff_ptr_ch_d + 1;
+                        ff_cnt_ch_d := reg_freq_ch_d;
+                    else
+                        ff_cnt_ch_d := ff_cnt_ch_d - 1;
+                    end if;
+
+                    if (reg_freq_ch_e(11 downto 3) = "000000000" or ff_rst_ch_e = '1') then
+                        ff_ptr_ch_e <= "00000";
+                        ff_cnt_ch_e := reg_freq_ch_e;
+                    elsif (ff_cnt_ch_e = x"000") then
+                        ff_ptr_ch_e <= ff_ptr_ch_e + 1;
+                        ff_cnt_ch_e := reg_freq_ch_e;
+                    else
+                        ff_cnt_ch_e := ff_cnt_ch_e - 1;
+                    end if;
+
                 end if;
-
-                if (reg_freq_ch_b(11 downto 3) = "000000000" or ff_rst_ch_b = '1') then
-                    ff_ptr_ch_b <= "00000";
-                    ff_cnt_ch_b := reg_freq_ch_b;
-                elsif (ff_cnt_ch_b = x"000") then
-                    ff_ptr_ch_b <= ff_ptr_ch_b + 1;
-                    ff_cnt_ch_b := reg_freq_ch_b;
-                else
-                    ff_cnt_ch_b := ff_cnt_ch_b - 1;
-                end if;
-
-                if (reg_freq_ch_c(11 downto 3) = "000000000" or ff_rst_ch_c = '1') then
-                    ff_ptr_ch_c <= "00000";
-                    ff_cnt_ch_c := reg_freq_ch_c;
-                elsif (ff_cnt_ch_c = x"000") then
-                    ff_ptr_ch_c <= ff_ptr_ch_c + 1;
-                    ff_cnt_ch_c := reg_freq_ch_c;
-                else
-                    ff_cnt_ch_c := ff_cnt_ch_c - 1;
-                end if;
-
-                if (reg_freq_ch_d(11 downto 3) = "000000000" or ff_rst_ch_d = '1') then
-                    ff_ptr_ch_d <= "00000";
-                    ff_cnt_ch_d := reg_freq_ch_d;
-                elsif (ff_cnt_ch_d = x"000") then
-                    ff_ptr_ch_d <= ff_ptr_ch_d + 1;
-                    ff_cnt_ch_d := reg_freq_ch_d;
-                else
-                    ff_cnt_ch_d := ff_cnt_ch_d - 1;
-                end if;
-
-                if (reg_freq_ch_e(11 downto 3) = "000000000" or ff_rst_ch_e = '1') then
-                    ff_ptr_ch_e <= "00000";
-                    ff_cnt_ch_e := reg_freq_ch_e;
-                elsif (ff_cnt_ch_e = x"000") then
-                    ff_ptr_ch_e <= ff_ptr_ch_e + 1;
-                    ff_cnt_ch_e := reg_freq_ch_e;
-                else
-                    ff_cnt_ch_e := ff_cnt_ch_e - 1;
-                end if;
-
             end if;
         end if;
     end process;
@@ -334,12 +340,14 @@ begin
     --  wave memory read
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            dbi <= (others => '1');
-        elsif( clk21m'event and clk21m = '1' )then
-            -- mapped i/o port access on b800-bfffh (9800-9fffh) ... wave memory read data
-            if( ff_wave_ce = '1' )then
-                dbi <= ram_dbi;
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
+                dbi <= (others => '1');
+            else
+                -- mapped i/o port access on b800-bfffh (9800-9fffh) ... wave memory read data
+                if( ff_wave_ce = '1' )then
+                    dbi <= ram_dbi;
+                end if;
             end if;
         end if;
     end process;
@@ -349,16 +357,18 @@ begin
     ----------------------------------------------------------------
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            ff_wave_ce      <= '0';
-            ff_wave_ce_dl   <= '0';
-            ff_wave_dat     <= (others => '0');
-            ff_ch_num_dl    <= (others => '0');
-        elsif( clk21m'event and clk21m = '1' )then
-            ff_wave_ce      <= w_wave_ce;
-            ff_wave_ce_dl   <= ff_wave_ce;
-            ff_wave_dat     <= ram_dbi;
-            ff_ch_num_dl    <= ff_ch_num;
+        if( rising_edge(clk21m) ) then
+            if( reset = '1' )then
+                ff_wave_ce      <= '0';
+                ff_wave_ce_dl   <= '0';
+                ff_wave_dat     <= (others => '0');
+                ff_ch_num_dl    <= (others => '0');
+            else
+                ff_wave_ce      <= w_wave_ce;
+                ff_wave_ce_dl   <= ff_wave_ce;
+                ff_wave_dat     <= ram_dbi;
+                ff_ch_num_dl    <= ff_ch_num;
+            end if;
         end if;
     end process;
 
@@ -389,13 +399,13 @@ begin
         reg_vol_ch_e        when "101",
         (others => '0') when others;
 
-    w_wave  <=  (w_ch_mask and ff_wave_dat);        -- 8bit ìÒÇÃï‚êî
+    w_wave  <=  (w_ch_mask and ff_wave_dat);        -- 8bit ÔøΩÔøΩÃï‚êî
 
     u_mul: scc_wave_mul
     port map (
-        a   => w_wave   ,   -- 8bit ìÒÇÃï‚êî
-        b   => w_ch_vol ,   -- 4bit ÉoÉCÉiÉäÅiïÑçÜñ≥ÇµÅj
-        c   => w_mul        -- 12bit ìÒÇÃï‚êî
+        a   => w_wave   ,   -- 8bit ÔøΩÔøΩÃï‚êî
+        b   => w_ch_vol ,   -- 4bit ÔøΩoÔøΩCÔøΩiÔøΩÔøΩÔøΩiÔøΩÔøΩÔøΩÔøΩÔøΩÔøΩÔøΩÔøΩÔøΩj
+        c   => w_mul        -- 12bit ÔøΩÔøΩÃï‚êî
     );
 
     -- -------------------------------------------------------------
@@ -432,18 +442,20 @@ begin
     --  ff_mix                        X a   X ab  X a-c X a-d X a-e       X 0   X a   X ab  X
     --  wave                                                              X a-e
     --                                                                     ~~~~~
-    --  wave ÇÕÅAff_wave_ce_dl = 0 and ff_ch_num_dl = 0 ÇÃÇ∆Ç´ ff_mix ÇéÊÇËçûÇﬁ
+    --  wave ÔøΩÕÅAff_wave_ce_dl = 0 and ff_ch_num_dl = 0 ÔøΩÃÇ∆ÇÔøΩ ff_mix ÔøΩÔøΩÔøΩÔøΩËçûÔøΩÔøΩ
     ----------------------------------------------------------------
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            ff_ch_num <= "000";
-        elsif( clk21m'event and clk21m = '1' )then
-            if( ff_wave_ce = '0' )then
-                if( ff_ch_num = "101" )then
-                    ff_ch_num <= "000";
-                else
-                    ff_ch_num <= ff_ch_num + 1;
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
+                ff_ch_num <= "000";
+            else
+                if( ff_wave_ce = '0' )then
+                    if( ff_ch_num = "101" )then
+                        ff_ch_num <= "000";
+                    else
+                        ff_ch_num <= ff_ch_num + 1;
+                    end if;
                 end if;
             end if;
         end if;
@@ -452,14 +464,16 @@ begin
     --  mixer
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            ff_mix  <= (others => '0');
-        elsif( clk21m'event and clk21m = '1' )then
-            if( ff_wave_ce_dl = '0' )then
-                if( ff_ch_num_dl = "000" )then
-                    ff_mix  <=  (others => '0');
-                else
-                    ff_mix  <=  (w_mul(11) & w_mul(11) & w_mul(11) & w_mul) + ff_mix;   -- 15bit ìÒÇÃï‚êî
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
+                ff_mix  <= (others => '0');
+            else
+                if( ff_wave_ce_dl = '0' )then
+                    if( ff_ch_num_dl = "000" )then
+                        ff_mix  <=  (others => '0');
+                    else
+                        ff_mix  <=  (w_mul(11) & w_mul(11) & w_mul(11) & w_mul) + ff_mix;   -- 15bit ÔøΩÔøΩÃï‚êî
+                    end if;
                 end if;
             end if;
         end if;
@@ -468,14 +482,16 @@ begin
     --  wave out
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            ff_wave <= (others => '0');
-        elsif( clk21m'event and clk21m = '1' )then
-            if( ff_wave_ce_dl = '0' )then
-                if( ff_ch_num_dl = "000" )then
-                    ff_wave <= ff_mix;  -- 15bit ìÒÇÃï‚êî
-                else
-                    --  hold
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
+                ff_wave <= (others => '0');
+            else
+                if( ff_wave_ce_dl = '0' )then
+                    if( ff_ch_num_dl = "000" )then
+                        ff_wave <= ff_mix;  -- 15bit ÔøΩÔøΩÃï‚êî
+                    else
+                        --  hold
+                    end if;
                 end if;
             end if;
         end if;

--- a/VIDEO/vdp_colordec.vhd
+++ b/VIDEO/vdp_colordec.vhd
@@ -143,27 +143,29 @@ BEGIN
     -- OUTPUT DATA LATCH
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_VIDEO_R <= "000000";
-            FF_VIDEO_G <= "000000";
-            FF_VIDEO_B <= "000000";
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( W_EVEN_DOTSTATE = '1' )THEN
-                IF( VDPMODEGRAPHIC7 = '1' AND FF_YJK_EN = '1' AND FF_SPRITECOLOROUT = '0' )THEN
-                    --  YJK MODE
-                    FF_VIDEO_R <= FF_YJK_R;
-                    FF_VIDEO_G <= FF_YJK_G;
-                    FF_VIDEO_B <= FF_YJK_B;
-                ELSIF( VDPMODEGRAPHIC7 = '0' OR REG_R25_YJK = '1' )THEN
-                    --  PALETTE COLOR (NOT GRAPHIC7, SPRITE ON YJK MODE, YAE COLOR ON YJK MODE)
-                    FF_VIDEO_R <= PALETTEDATARB_OUT( 6 DOWNTO 4 ) & "000";
-                    FF_VIDEO_G <= PALETTEDATAG_OUT(  2 DOWNTO 0 ) & "000";
-                    FF_VIDEO_B <= PALETTEDATARB_OUT( 2 DOWNTO 0 ) & "000";
-                ELSE
-                    --  GRAPHIC7
-                    FF_VIDEO_R <= FF_GRP7_COLOR_CODE( 4 DOWNTO 2 ) & "000";
-                    FF_VIDEO_G <= FF_GRP7_COLOR_CODE( 7 DOWNTO 5 ) & "000";
-                    FF_VIDEO_B <= FF_GRP7_COLOR_CODE( 1 DOWNTO 0 ) & FF_GRP7_COLOR_CODE(1) & "000";
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_VIDEO_R <= "000000";
+                FF_VIDEO_G <= "000000";
+                FF_VIDEO_B <= "000000";
+	    ELSE
+                IF( W_EVEN_DOTSTATE = '1' )THEN
+                    IF( VDPMODEGRAPHIC7 = '1' AND FF_YJK_EN = '1' AND FF_SPRITECOLOROUT = '0' )THEN
+                        --  YJK MODE
+                        FF_VIDEO_R <= FF_YJK_R;
+                        FF_VIDEO_G <= FF_YJK_G;
+                        FF_VIDEO_B <= FF_YJK_B;
+                    ELSIF( VDPMODEGRAPHIC7 = '0' OR REG_R25_YJK = '1' )THEN
+                        --  PALETTE COLOR (NOT GRAPHIC7, SPRITE ON YJK MODE, YAE COLOR ON YJK MODE)
+                        FF_VIDEO_R <= PALETTEDATARB_OUT( 6 DOWNTO 4 ) & "000";
+                        FF_VIDEO_G <= PALETTEDATAG_OUT(  2 DOWNTO 0 ) & "000";
+                        FF_VIDEO_B <= PALETTEDATARB_OUT( 2 DOWNTO 0 ) & "000";
+                    ELSE
+                        --  GRAPHIC7
+                        FF_VIDEO_R <= FF_GRP7_COLOR_CODE( 4 DOWNTO 2 ) & "000";
+                        FF_VIDEO_G <= FF_GRP7_COLOR_CODE( 7 DOWNTO 5 ) & "000";
+                        FF_VIDEO_B <= FF_GRP7_COLOR_CODE( 1 DOWNTO 0 ) & FF_GRP7_COLOR_CODE(1) & "000";
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -198,38 +200,15 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_PALETTE_ADDR     <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( W_EVEN_DOTSTATE = '1' )THEN
-                IF( WINDOW = '0' OR REG_R1_DISP_ON = '0' OR (W_FORE_COLOR = "0000" AND REG_R8_COL0_ON = '0') )THEN
-                    FF_PALETTE_ADDR     <= W_BACK_COLOR;
-                ELSE
-                    FF_PALETTE_ADDR     <= W_FORE_COLOR;
-                END IF;
-            END IF;
-        END IF;
-    END PROCESS;
-
-    PROCESS( RESET, CLK21M )
-    BEGIN
-        IF( RESET = '1' )THEN
-            FF_PALETTE_ADDR_G5  <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( W_EVEN_DOTSTATE = '1' )THEN
-                IF( WINDOW = '0' OR REG_R1_DISP_ON = '0' OR
-                        (DOTSTATE(1) = '0' AND W_FORE_COLOR( 1 DOWNTO 0 ) = "00" AND REG_R8_COL0_ON = '0') OR
-                        (DOTSTATE(1) = '1' AND W_FORE_COLOR( 3 DOWNTO 2 ) = "00" AND REG_R8_COL0_ON = '0') )THEN
-                    IF( DOTSTATE(1) = '0' )THEN
-                        FF_PALETTE_ADDR_G5  <= W_BACK_COLOR( 1 DOWNTO 0 );
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_PALETTE_ADDR     <= (OTHERS => '0');
+	    ELSE
+                IF( W_EVEN_DOTSTATE = '1' )THEN
+                    IF( WINDOW = '0' OR REG_R1_DISP_ON = '0' OR (W_FORE_COLOR = "0000" AND REG_R8_COL0_ON = '0') )THEN
+                        FF_PALETTE_ADDR     <= W_BACK_COLOR;
                     ELSE
-                        FF_PALETTE_ADDR_G5  <= W_BACK_COLOR( 3 DOWNTO 2 );
-                    END IF;
-                ELSE
-                    IF( DOTSTATE(1) = '0' )THEN
-                        FF_PALETTE_ADDR_G5  <= W_FORE_COLOR( 1 DOWNTO 0 );
-                    ELSE
-                        FF_PALETTE_ADDR_G5  <= W_FORE_COLOR( 3 DOWNTO 2 );
+                        FF_PALETTE_ADDR     <= W_FORE_COLOR;
                     END IF;
                 END IF;
             END IF;
@@ -238,14 +217,26 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_GRP7_COLOR_CODE  <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( W_EVEN_DOTSTATE = '1' )THEN
-                IF( SPRITECOLOROUT = '1' )THEN
-                    FF_GRP7_COLOR_CODE  <= W_GRP7_SPRITE_COLOR;
-                ELSE
-                    FF_GRP7_COLOR_CODE  <= COLORCODEG4567;
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_PALETTE_ADDR_G5  <= (OTHERS => '0');
+	    ELSE
+                IF( W_EVEN_DOTSTATE = '1' )THEN
+                    IF( WINDOW = '0' OR REG_R1_DISP_ON = '0' OR
+                            (DOTSTATE(1) = '0' AND W_FORE_COLOR( 1 DOWNTO 0 ) = "00" AND REG_R8_COL0_ON = '0') OR
+                            (DOTSTATE(1) = '1' AND W_FORE_COLOR( 3 DOWNTO 2 ) = "00" AND REG_R8_COL0_ON = '0') )THEN
+                        IF( DOTSTATE(1) = '0' )THEN
+                            FF_PALETTE_ADDR_G5  <= W_BACK_COLOR( 1 DOWNTO 0 );
+                        ELSE
+                            FF_PALETTE_ADDR_G5  <= W_BACK_COLOR( 3 DOWNTO 2 );
+                        END IF;
+                    ELSE
+                        IF( DOTSTATE(1) = '0' )THEN
+                            FF_PALETTE_ADDR_G5  <= W_FORE_COLOR( 1 DOWNTO 0 );
+                        ELSE
+                            FF_PALETTE_ADDR_G5  <= W_FORE_COLOR( 3 DOWNTO 2 );
+                        END IF;
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -253,27 +244,46 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_SPRITECOLOROUT   <= '0';
-            FF_YJK_R            <= (OTHERS => '0');
-            FF_YJK_G            <= (OTHERS => '0');
-            FF_YJK_B            <= (OTHERS => '0');
-            FF_YJK_EN           <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( W_EVEN_DOTSTATE = '1' )THEN
-                FF_SPRITECOLOROUT   <= SPRITECOLOROUT AND WINDOW AND REG_R1_DISP_ON;
-                IF( WINDOW = '1' AND REG_R1_DISP_ON = '1' )THEN
-                    FF_YJK_R            <= P_YJK_R;
-                    FF_YJK_G            <= P_YJK_G;
-                    FF_YJK_B            <= P_YJK_B;
-                    FF_YJK_EN           <= P_YJK_EN;
-                ELSIF( (WINDOW = '0' OR REG_R1_DISP_ON = '0') AND REG_R25_YJK = '1' )THEN
-                    FF_YJK_EN           <= '0';
-                ELSE
-                    FF_YJK_R            <= REG_R7_FRAME_COL( 4 DOWNTO 2 ) & "000";
-                    FF_YJK_G            <= REG_R7_FRAME_COL( 7 DOWNTO 5 ) & "000";
-                    FF_YJK_B            <= REG_R7_FRAME_COL( 1 DOWNTO 0 ) & REG_R7_FRAME_COL(1) & "000";
-                    FF_YJK_EN           <= '1';
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_GRP7_COLOR_CODE  <= (OTHERS => '0');
+	    ELSE
+                IF( W_EVEN_DOTSTATE = '1' )THEN
+                    IF( SPRITECOLOROUT = '1' )THEN
+                        FF_GRP7_COLOR_CODE  <= W_GRP7_SPRITE_COLOR;
+                    ELSE
+                        FF_GRP7_COLOR_CODE  <= COLORCODEG4567;
+                    END IF;
+                END IF;
+            END IF;
+        END IF;
+    END PROCESS;
+
+    PROCESS( RESET, CLK21M )
+    BEGIN
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_SPRITECOLOROUT   <= '0';
+                FF_YJK_R            <= (OTHERS => '0');
+                FF_YJK_G            <= (OTHERS => '0');
+                FF_YJK_B            <= (OTHERS => '0');
+                FF_YJK_EN           <= '0';
+	    ELSE
+                IF( W_EVEN_DOTSTATE = '1' )THEN
+                    FF_SPRITECOLOROUT   <= SPRITECOLOROUT AND WINDOW AND REG_R1_DISP_ON;
+                    IF( WINDOW = '1' AND REG_R1_DISP_ON = '1' )THEN
+                        FF_YJK_R            <= P_YJK_R;
+                        FF_YJK_G            <= P_YJK_G;
+                        FF_YJK_B            <= P_YJK_B;
+                        FF_YJK_EN           <= P_YJK_EN;
+                    ELSIF( (WINDOW = '0' OR REG_R1_DISP_ON = '0') AND REG_R25_YJK = '1' )THEN
+                        FF_YJK_EN           <= '0';
+                    ELSE
+                        FF_YJK_R            <= REG_R7_FRAME_COL( 4 DOWNTO 2 ) & "000";
+                        FF_YJK_G            <= REG_R7_FRAME_COL( 7 DOWNTO 5 ) & "000";
+                        FF_YJK_B            <= REG_R7_FRAME_COL( 1 DOWNTO 0 ) & REG_R7_FRAME_COL(1) & "000";
+                        FF_YJK_EN           <= '1';
+                    END IF;
                 END IF;
             END IF;
         END IF;

--- a/VIDEO/vdp_command.vhd
+++ b/VIDEO/vdp_command.vhd
@@ -217,567 +217,569 @@ BEGIN
         VARIABLE VDPVRAMACCESSY : STD_LOGIC_VECTOR(9 DOWNTO 0);
         VARIABLE VDPVRAMACCESSX : STD_LOGIC_VECTOR(8 DOWNTO 0);
     BEGIN
-        IF (RESET = '1') THEN
-            STATE <= STIDLE;    -- VERY IMPORTANT FOR XILINX SYNTHESIS TOOL(XST)
-            INITIALIZING := '0';
-            NXCOUNT := (OTHERS => '0');
-            NXLOOPEND := '0';
-            XCOUNTDELTA := (OTHERS => '0');
-            YCOUNTDELTA := (OTHERS => '0');
-            COLMASK := (OTHERS => '1');
-            RDXLOW := "00";
-            SX <= (OTHERS => '0');  -- R32
-            SY <= (OTHERS => '0');  -- R34
-            DX <= (OTHERS => '0');  -- R36
-            DY <= (OTHERS => '0');  -- R38
-            NX <= (OTHERS => '0');  -- R40
-            NY <= (OTHERS => '0');  -- R42
-            CLR <= (OTHERS => '0'); -- R44
-            MM  <= '0'; -- R45 BIT 0
-            EQ  <= '0'; -- R45 BIT 1
-            DIX <= '0'; -- R45 BIT 2
-            DIY <= '0'; -- R45 BIT 3
---          MXS <= '0'; -- R45 BIT 4
---          MXD <= '0'; -- R45 BIT 5
-            CMR <= (OTHERS => '0'); -- R46
-            SXTMP <= (OTHERS => '0');
-            DXTMP <= (OTHERS => '0');
-            CMRWR <= '0';
-            REGWRACK <= '0';
-            VRAMWRREQ <= '0';
-            VRAMRDREQ <= '0';
-            VRAMWRDATA <= (OTHERS => '0');
+        IF (RISING_EDGE(CLK21M)) THEN
+            IF (RESET = '1') THEN
+                STATE <= STIDLE;    -- VERY IMPORTANT FOR XILINX SYNTHESIS TOOL(XST)
+                INITIALIZING := '0';
+                NXCOUNT := (OTHERS => '0');
+                NXLOOPEND := '0';
+                XCOUNTDELTA := (OTHERS => '0');
+                YCOUNTDELTA := (OTHERS => '0');
+                COLMASK := (OTHERS => '1');
+                RDXLOW := "00";
+                SX <= (OTHERS => '0');  -- R32
+                SY <= (OTHERS => '0');  -- R34
+                DX <= (OTHERS => '0');  -- R36
+                DY <= (OTHERS => '0');  -- R38
+                NX <= (OTHERS => '0');  -- R40
+                NY <= (OTHERS => '0');  -- R42
+                CLR <= (OTHERS => '0'); -- R44
+                MM  <= '0'; -- R45 BIT 0
+                EQ  <= '0'; -- R45 BIT 1
+                DIX <= '0'; -- R45 BIT 2
+                DIY <= '0'; -- R45 BIT 3
+--              MXS <= '0'; -- R45 BIT 4
+--              MXD <= '0'; -- R45 BIT 5
+                CMR <= (OTHERS => '0'); -- R46
+                SXTMP <= (OTHERS => '0');
+                DXTMP <= (OTHERS => '0');
+                CMRWR <= '0';
+                REGWRACK <= '0';
+                VRAMWRREQ <= '0';
+                VRAMRDREQ <= '0';
+                VRAMWRDATA <= (OTHERS => '0');
 
-            TR <= '1'; -- TRANSFER READY
-            CE <= '0'; -- COMMAND EXECUTING
-            BD <= '0'; -- BORDER COLOR FOUND
-            TRCLRACK <= '0';
-            VDPVRAMACCESSY := (OTHERS => '0');
-            VDPVRAMACCESSX := (OTHERS => '0');
-            VRAMACCESSADDR <= (OTHERS => '0');
-        ELSIF (CLK21M'EVENT AND CLK21M = '1') THEN
-            IF( (VDPMODEGRAPHIC4 = '1') OR (VDPMODEGRAPHIC6 = '1') ) THEN
-                GRAPHIC4_OR_6 := '1';
-            ELSE
-                GRAPHIC4_OR_6 := '0';
-            END IF;
+                TR <= '1'; -- TRANSFER READY
+                CE <= '0'; -- COMMAND EXECUTING
+                BD <= '0'; -- BORDER COLOR FOUND
+                TRCLRACK <= '0';
+                VDPVRAMACCESSY := (OTHERS => '0');
+                VDPVRAMACCESSX := (OTHERS => '0');
+                VRAMACCESSADDR <= (OTHERS => '0');
+	    ELSE
+                IF( (VDPMODEGRAPHIC4 = '1') OR (VDPMODEGRAPHIC6 = '1') ) THEN
+                    GRAPHIC4_OR_6 := '1';
+                ELSE
+                    GRAPHIC4_OR_6 := '0';
+                END IF;
 
 
-            CASE CMR(7 DOWNTO 6) IS
-                WHEN "11" =>
-                    -- BYTE COMMAND
-                    IF( GRAPHIC4_OR_6 = '1' ) THEN
-                        -- GRAPHIC4,6 (SCREEN 5, 7)
-                        NXCOUNT := "0" & NX(9 DOWNTO 1);
-                        IF (DIX = '0') THEN
-                            XCOUNTDELTA := "00000000010"; -- +2
+                CASE CMR(7 DOWNTO 6) IS
+                    WHEN "11" =>
+                        -- BYTE COMMAND
+                        IF( GRAPHIC4_OR_6 = '1' ) THEN
+                            -- GRAPHIC4,6 (SCREEN 5, 7)
+                            NXCOUNT := "0" & NX(9 DOWNTO 1);
+                            IF (DIX = '0') THEN
+                                XCOUNTDELTA := "00000000010"; -- +2
+                            ELSE
+                                XCOUNTDELTA := "11111111110"; -- -2
+                            END IF;
+                        ELSIF( VDPMODEGRAPHIC5 = '1' ) THEN
+                            -- GRAPHIC5 (SCREEN 6)
+                            NXCOUNT := "00" & NX(9 DOWNTO 2);
+                            IF (DIX = '0') THEN
+                                XCOUNTDELTA := "00000000100"; -- +4
+                            ELSE
+                                XCOUNTDELTA := "11111111100"; -- -4;
+                            END IF;
                         ELSE
-                            XCOUNTDELTA := "11111111110"; -- -2
+                            -- GRAPHIC7 (SCREEN 8) AND OTHER
+                            NXCOUNT := NX;
+                            IF (DIX = '0') THEN
+                                XCOUNTDELTA := "00000000001"; -- +1
+                            ELSE
+                                XCOUNTDELTA := "11111111111"; -- -1
+                            END IF;
                         END IF;
-                    ELSIF( VDPMODEGRAPHIC5 = '1' ) THEN
-                        -- GRAPHIC5 (SCREEN 6)
-                        NXCOUNT := "00" & NX(9 DOWNTO 2);
-                        IF (DIX = '0') THEN
-                            XCOUNTDELTA := "00000000100"; -- +4
-                        ELSE
-                            XCOUNTDELTA := "11111111100"; -- -4;
-                        END IF;
-                    ELSE
-                        -- GRAPHIC7 (SCREEN 8) AND OTHER
+                        COLMASK := (OTHERS => '1');
+                    WHEN OTHERS =>
+                        -- DOT COMMAND
                         NXCOUNT := NX;
                         IF (DIX = '0') THEN
-                            XCOUNTDELTA := "00000000001"; -- +1
+                            XCOUNTDELTA := "00000000001"; -- +1;
                         ELSE
-                            XCOUNTDELTA := "11111111111"; -- -1
+                            XCOUNTDELTA := "11111111111"; -- -1;
                         END IF;
-                    END IF;
-                    COLMASK := (OTHERS => '1');
-                WHEN OTHERS =>
-                    -- DOT COMMAND
-                    NXCOUNT := NX;
-                    IF (DIX = '0') THEN
-                        XCOUNTDELTA := "00000000001"; -- +1;
-                    ELSE
-                        XCOUNTDELTA := "11111111111"; -- -1;
-                    END IF;
-                    IF (GRAPHIC4_OR_6 = '1') THEN
-                        COLMASK := "00001111";
-                    ELSIF (VDPMODEGRAPHIC5 = '1') THEN
-                        COLMASK := "00000011";
-                    ELSE
-                        COLMASK := (OTHERS => '1');
-                    END IF;
-            END CASE;
+                        IF (GRAPHIC4_OR_6 = '1') THEN
+                            COLMASK := "00001111";
+                        ELSIF (VDPMODEGRAPHIC5 = '1') THEN
+                            COLMASK := "00000011";
+                        ELSE
+                            COLMASK := (OTHERS => '1');
+                        END IF;
+                END CASE;
 
-            IF (DIY = '0') THEN
-                YCOUNTDELTA := "0000000001";
-            ELSE
-                YCOUNTDELTA := "1111111111";
-            END IF;
-
-
-            IF (VDPMODEISHIGHRES = '1') THEN
-                -- GRAPHIC 5,6 (SCREEN 6, 7)
-                MAXXMASK := "10";
-            ELSE
-                MAXXMASK := "01";
-            END IF;
-
-            -- DETERMINE IF X-LOOP IS FINISHED
-            CASE CMR(7 DOWNTO 4) IS
-                WHEN HMMV | HMMC | LMMV | LMMC =>
-                    IF ((NXTMP = 0) OR
-                            ((DXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK)) THEN
-                        NXLOOPEND := '1';
-                    ELSE
-                        NXLOOPEND := '0';
-                    END IF;
-                WHEN YMMM =>
-                    IF ((DXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK) THEN
-                        NXLOOPEND := '1';
-                    ELSE
-                        NXLOOPEND := '0';
-                    END IF;
-                WHEN HMMM | LMMM =>
-                    IF ((NXTMP = 0) OR
-                            ((SXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK) OR
-                            ((DXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK)) THEN
-                        NXLOOPEND := '1';
-                    ELSE
-                        NXLOOPEND := '0';
-                    END IF;
-                WHEN LMCM =>
-                    IF ((NXTMP = 0) OR
-                            ((SXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK)) THEN
-                        NXLOOPEND := '1';
-                    ELSE
-                        NXLOOPEND := '0';
-                    END IF;
-                WHEN SRCH =>
-                    IF ((SXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK) THEN
-                        NXLOOPEND := '1';
-                    ELSE
-                        NXLOOPEND := '0';
-                    END IF;
-                WHEN OTHERS =>
-                    NXLOOPEND := '1';
-            END CASE;
-
-            -- RETRIEVE THE 'POINT' OUT OF THE BYTE THAT WAS MOST RECENTLY READ
-            IF (GRAPHIC4_OR_6 = '1') THEN
-                -- SCREEN 5, 7
-                IF( RDXLOW(0) = '0' ) THEN
-                    RDPOINT := "0000" & VRAMRDDATA(7 DOWNTO 4);
+                IF (DIY = '0') THEN
+                    YCOUNTDELTA := "0000000001";
                 ELSE
-                    RDPOINT := "0000" & VRAMRDDATA(3 DOWNTO 0);
+                    YCOUNTDELTA := "1111111111";
                 END IF;
-            ELSIF (VDPMODEGRAPHIC5 = '1') THEN
-                -- SCREEN 6
-                CASE RDXLOW IS
-                    WHEN "00" =>
-                        RDPOINT := "000000" & VRAMRDDATA(7 DOWNTO 6);
-                    WHEN "01" =>
-                        RDPOINT := "000000" & VRAMRDDATA(5 DOWNTO 4);
-                    WHEN "10" =>
-                        RDPOINT := "000000" & VRAMRDDATA(3 DOWNTO 2);
-                    WHEN OTHERS =>
---                  WHEN "11" =>
-                        RDPOINT := "000000" & VRAMRDDATA(1 DOWNTO 0);
---                  WHEN OTHERS =>
---                      NULL; -- SHOULD NEVER OCCUR
-                END CASE;
-            ELSE
-                -- SCREEN 8 AND OTHER MODES
-                RDPOINT := VRAMRDDATA;
-            END IF;
 
-            -- PERFORM LOGICAL OPERATION ON MOST RECENTLY READ POINT AND
-            -- ON THE POINT TO BE WRITTEN.
-            IF ((CMR(3) = '0') OR ((VRAMWRDATA AND COLMASK) /= "00000000")) THEN
-                CASE CMR(2 DOWNTO 0) IS
-                    WHEN IMPB210 =>
-                        LOGOPDESTCOL := (VRAMWRDATA AND COLMASK);
-                    WHEN ANDB210 =>
-                        LOGOPDESTCOL := (VRAMWRDATA AND COLMASK) AND RDPOINT;
-                    WHEN ORB210 =>
-                        LOGOPDESTCOL := (VRAMWRDATA AND COLMASK) OR RDPOINT;
-                    WHEN EORB210 =>
-                        LOGOPDESTCOL := (VRAMWRDATA AND COLMASK) XOR RDPOINT;
-                    WHEN NOTB210 =>
-                        LOGOPDESTCOL := NOT (VRAMWRDATA AND COLMASK);
-                    WHEN OTHERS =>
-                        LOGOPDESTCOL := RDPOINT;
-                END CASE;
-            ELSE
-                LOGOPDESTCOL := RDPOINT;
-            END IF;
 
-            -- PROCESS REGISTER UPDATE REQUEST, CLEAR 'TRANSFER READY' REQUEST
-            -- OR PROCESS ANY ONGOING COMMAND.
-            IF( REGWRREQ /= REGWRACK ) THEN
-                REGWRACK <= NOT REGWRACK;
-                CASE REGNUM IS
-                    WHEN "0000" =>      -- #32
-                        SX(7 DOWNTO 0) <= REGDATA;
-                    WHEN "0001" =>      -- #33
-                        SX(8) <= REGDATA(0);
-                    WHEN "0010" =>      -- #34
-                        SY(7 DOWNTO 0) <= REGDATA;
-                    WHEN "0011" =>      -- #35
-                        SY(9 DOWNTO 8) <= REGDATA(1 DOWNTO 0);
-                    WHEN "0100" =>      -- #36
-                        DX(7 DOWNTO 0) <= REGDATA;
-                    WHEN "0101" =>      -- #37
-                        DX(8) <= REGDATA(0);
-                    WHEN "0110" =>      -- #38
-                        DY(7 DOWNTO 0) <= REGDATA;
-                    WHEN "0111" =>      -- #39
-                        DY(9 DOWNTO 8) <= REGDATA(1 DOWNTO 0);
-                    WHEN "1000" =>      -- #40
-                        NX(7 DOWNTO 0) <= REGDATA;
-                    WHEN "1001" =>      -- #41
-                        NX(9 DOWNTO 8) <= REGDATA(1 DOWNTO 0);
-                    WHEN "1010" =>      -- #42
-                        NY(7 DOWNTO 0) <= REGDATA;
-                    WHEN "1011" =>      -- #43
-                        NY(9 DOWNTO 8) <= REGDATA(1 DOWNTO 0);
-                    WHEN "1100" =>      -- #44
-                        IF (CE = '1') THEN
-                            CLR <= REGDATA AND COLMASK;
+                IF (VDPMODEISHIGHRES = '1') THEN
+                    -- GRAPHIC 5,6 (SCREEN 6, 7)
+                    MAXXMASK := "10";
+                ELSE
+                    MAXXMASK := "01";
+                END IF;
+
+                -- DETERMINE IF X-LOOP IS FINISHED
+                CASE CMR(7 DOWNTO 4) IS
+                    WHEN HMMV | HMMC | LMMV | LMMC =>
+                        IF ((NXTMP = 0) OR
+                                ((DXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK)) THEN
+                            NXLOOPEND := '1';
                         ELSE
-                            CLR <= REGDATA;
+                            NXLOOPEND := '0';
                         END IF;
-                        TR <= '0'; -- DATA IS TRANSFERRED FROM CPU TO VDP COLOR REGISTER
-                    WHEN "1101" =>      -- #45
-                        MM  <= REGDATA(0);
-                        EQ  <= REGDATA(1);
-                        DIX <= REGDATA(2);
-                        DIY <= REGDATA(3);
---                      MXD <= REGDATA(5);
-                    WHEN "1110" =>      -- #46
-                        -- INITIALIZE THE NEW COMMAND
-                        -- NOTE THAT THIS WILL ABORT ANY ONGOING COMMAND!
-                        CMR <= REGDATA;
-                        CMRWR <= W_VDPCMD_EN;
-                        STATE <= STIDLE;
-                    WHEN OTHERS =>
-                        NULL;
-                END CASE;
-            ELSIF( TRCLRREQ /= TRCLRACK ) THEN
-                -- RESET THE DATA TRANSFER REGISTER (CPU HAS JUST READ THE COLOR REGISTER)
-                TRCLRACK <= NOT TRCLRACK;
-                TR <= '0';
-            ELSE
-                -- PROCESS THE VDP COMMAND STATE
-                CASE STATE IS
-                    WHEN STIDLE =>
-                        IF( CMRWR = '0' ) THEN
-                            CE <= '0';
-                            CE <= '0';
+                    WHEN YMMM =>
+                        IF ((DXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK) THEN
+                            NXLOOPEND := '1';
                         ELSE
-                            -- EXEC NEW VDP COMMAND
-                            CMRWR <= '0';
-                            CE <= '1';
-                            BD <= '0';
-                            IF CMR(7 DOWNTO 4) = LINE THEN
-                                -- LINE COMMAND REQUIRES SPECIAL SXTMP AND NXTMP SET-UP
-                                NX_MINUS_ONE := NX - 1;
-                                SXTMP <= "00" & NX_MINUS_ONE(9 DOWNTO 1);
-                                NXTMP <= (OTHERS => '0');
+                            NXLOOPEND := '0';
+                        END IF;
+                    WHEN HMMM | LMMM =>
+                        IF ((NXTMP = 0) OR
+                                ((SXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK) OR
+                                ((DXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK)) THEN
+                            NXLOOPEND := '1';
+                        ELSE
+                            NXLOOPEND := '0';
+                        END IF;
+                    WHEN LMCM =>
+                        IF ((NXTMP = 0) OR
+                                ((SXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK)) THEN
+                            NXLOOPEND := '1';
+                        ELSE
+                            NXLOOPEND := '0';
+                        END IF;
+                    WHEN SRCH =>
+                        IF ((SXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK) THEN
+                            NXLOOPEND := '1';
+                        ELSE
+                            NXLOOPEND := '0';
+                        END IF;
+                    WHEN OTHERS =>
+                        NXLOOPEND := '1';
+                END CASE;
+
+                -- RETRIEVE THE 'POINT' OUT OF THE BYTE THAT WAS MOST RECENTLY READ
+                IF (GRAPHIC4_OR_6 = '1') THEN
+                    -- SCREEN 5, 7
+                    IF( RDXLOW(0) = '0' ) THEN
+                        RDPOINT := "0000" & VRAMRDDATA(7 DOWNTO 4);
+                    ELSE
+                        RDPOINT := "0000" & VRAMRDDATA(3 DOWNTO 0);
+                    END IF;
+                ELSIF (VDPMODEGRAPHIC5 = '1') THEN
+                    -- SCREEN 6
+                    CASE RDXLOW IS
+                        WHEN "00" =>
+                            RDPOINT := "000000" & VRAMRDDATA(7 DOWNTO 6);
+                        WHEN "01" =>
+                            RDPOINT := "000000" & VRAMRDDATA(5 DOWNTO 4);
+                        WHEN "10" =>
+                            RDPOINT := "000000" & VRAMRDDATA(3 DOWNTO 2);
+                        WHEN OTHERS =>
+--                      WHEN "11" =>
+                            RDPOINT := "000000" & VRAMRDDATA(1 DOWNTO 0);
+--                      WHEN OTHERS =>
+--                          NULL; -- SHOULD NEVER OCCUR
+                    END CASE;
+                ELSE
+                    -- SCREEN 8 AND OTHER MODES
+                    RDPOINT := VRAMRDDATA;
+                END IF;
+
+                -- PERFORM LOGICAL OPERATION ON MOST RECENTLY READ POINT AND
+                -- ON THE POINT TO BE WRITTEN.
+                IF ((CMR(3) = '0') OR ((VRAMWRDATA AND COLMASK) /= "00000000")) THEN
+                    CASE CMR(2 DOWNTO 0) IS
+                        WHEN IMPB210 =>
+                            LOGOPDESTCOL := (VRAMWRDATA AND COLMASK);
+                        WHEN ANDB210 =>
+                            LOGOPDESTCOL := (VRAMWRDATA AND COLMASK) AND RDPOINT;
+                        WHEN ORB210 =>
+                            LOGOPDESTCOL := (VRAMWRDATA AND COLMASK) OR RDPOINT;
+                        WHEN EORB210 =>
+                            LOGOPDESTCOL := (VRAMWRDATA AND COLMASK) XOR RDPOINT;
+                        WHEN NOTB210 =>
+                            LOGOPDESTCOL := NOT (VRAMWRDATA AND COLMASK);
+                        WHEN OTHERS =>
+                            LOGOPDESTCOL := RDPOINT;
+                    END CASE;
+                ELSE
+                    LOGOPDESTCOL := RDPOINT;
+                END IF;
+
+                -- PROCESS REGISTER UPDATE REQUEST, CLEAR 'TRANSFER READY' REQUEST
+                -- OR PROCESS ANY ONGOING COMMAND.
+                IF( REGWRREQ /= REGWRACK ) THEN
+                    REGWRACK <= NOT REGWRACK;
+                    CASE REGNUM IS
+                        WHEN "0000" =>      -- #32
+                            SX(7 DOWNTO 0) <= REGDATA;
+                        WHEN "0001" =>      -- #33
+                            SX(8) <= REGDATA(0);
+                        WHEN "0010" =>      -- #34
+                            SY(7 DOWNTO 0) <= REGDATA;
+                        WHEN "0011" =>      -- #35
+                            SY(9 DOWNTO 8) <= REGDATA(1 DOWNTO 0);
+                        WHEN "0100" =>      -- #36
+                            DX(7 DOWNTO 0) <= REGDATA;
+                        WHEN "0101" =>      -- #37
+                            DX(8) <= REGDATA(0);
+                        WHEN "0110" =>      -- #38
+                            DY(7 DOWNTO 0) <= REGDATA;
+                        WHEN "0111" =>      -- #39
+                            DY(9 DOWNTO 8) <= REGDATA(1 DOWNTO 0);
+                        WHEN "1000" =>      -- #40
+                            NX(7 DOWNTO 0) <= REGDATA;
+                        WHEN "1001" =>      -- #41
+                            NX(9 DOWNTO 8) <= REGDATA(1 DOWNTO 0);
+                        WHEN "1010" =>      -- #42
+                            NY(7 DOWNTO 0) <= REGDATA;
+                        WHEN "1011" =>      -- #43
+                            NY(9 DOWNTO 8) <= REGDATA(1 DOWNTO 0);
+                        WHEN "1100" =>      -- #44
+                            IF (CE = '1') THEN
+                                CLR <= REGDATA AND COLMASK;
                             ELSE
-                                IF CMR(7 DOWNTO 4) = YMMM THEN
-                                    -- FOR YMMM, SXTMP = DXTMP = DX
-                                    SXTMP <= "00" & DX;
-                                ELSE
-                                    -- FOR ALL OTHERS, SXTMP IS BUSINES AS USUAL
-                                    SXTMP <= "00" & SX;
-                                END IF;
-                                -- NXTMP IS BUSINESS AS USUAL FOR ALL BUT THE LINE COMMAND
-                                NXTMP <= NXCOUNT;
+                                CLR <= REGDATA;
                             END IF;
-                            DXTMP <= '0' & DX;
-                            INITIALIZING := '1';
-                            STATE <= STCHKLOOP;
-                        END IF;
-
-                    WHEN STRDCPU =>
-                        -- APPLICABLE TO HMMC, LMMC
-                        IF (TR = '0') THEN
-                            -- CPU HAS TRANSFERRED DATA TO (OR FROM) THE COLOR REGISTER
-                            TR <= '1';  -- VDP IS READY TO RECEIVE THE NEXT TRANSFER.
-                            VRAMWRDATA <= CLR;
-                            IF (CMR(6) = '0') THEN
-                                -- IT IS LMMC
-                                STATE <= STPRERDVRAM;
+                            TR <= '0'; -- DATA IS TRANSFERRED FROM CPU TO VDP COLOR REGISTER
+                        WHEN "1101" =>      -- #45
+                            MM  <= REGDATA(0);
+                            EQ  <= REGDATA(1);
+                            DIX <= REGDATA(2);
+                            DIY <= REGDATA(3);
+--                          MXD <= REGDATA(5);
+                        WHEN "1110" =>      -- #46
+                            -- INITIALIZE THE NEW COMMAND
+                            -- NOTE THAT THIS WILL ABORT ANY ONGOING COMMAND!
+                            CMR <= REGDATA;
+                            CMRWR <= W_VDPCMD_EN;
+                            STATE <= STIDLE;
+                        WHEN OTHERS =>
+                            NULL;
+                    END CASE;
+                ELSIF( TRCLRREQ /= TRCLRACK ) THEN
+                    -- RESET THE DATA TRANSFER REGISTER (CPU HAS JUST READ THE COLOR REGISTER)
+                    TRCLRACK <= NOT TRCLRACK;
+                    TR <= '0';
+                ELSE
+                    -- PROCESS THE VDP COMMAND STATE
+                    CASE STATE IS
+                        WHEN STIDLE =>
+                            IF( CMRWR = '0' ) THEN
+                                CE <= '0';
+                                CE <= '0';
                             ELSE
-                                -- IT IS HMMC
+                                -- EXEC NEW VDP COMMAND
+                                CMRWR <= '0';
+                                CE <= '1';
+                                BD <= '0';
+                                IF CMR(7 DOWNTO 4) = LINE THEN
+                                    -- LINE COMMAND REQUIRES SPECIAL SXTMP AND NXTMP SET-UP
+                                    NX_MINUS_ONE := NX - 1;
+                                    SXTMP <= "00" & NX_MINUS_ONE(9 DOWNTO 1);
+                                    NXTMP <= (OTHERS => '0');
+                                ELSE
+                                    IF CMR(7 DOWNTO 4) = YMMM THEN
+                                        -- FOR YMMM, SXTMP = DXTMP = DX
+                                        SXTMP <= "00" & DX;
+                                    ELSE
+                                        -- FOR ALL OTHERS, SXTMP IS BUSINES AS USUAL
+                                        SXTMP <= "00" & SX;
+                                    END IF;
+                                    -- NXTMP IS BUSINESS AS USUAL FOR ALL BUT THE LINE COMMAND
+                                    NXTMP <= NXCOUNT;
+                                END IF;
+                                DXTMP <= '0' & DX;
+                                INITIALIZING := '1';
+                                STATE <= STCHKLOOP;
+                            END IF;
+
+                        WHEN STRDCPU =>
+                            -- APPLICABLE TO HMMC, LMMC
+                            IF (TR = '0') THEN
+                                -- CPU HAS TRANSFERRED DATA TO (OR FROM) THE COLOR REGISTER
+                                TR <= '1';  -- VDP IS READY TO RECEIVE THE NEXT TRANSFER.
+                                VRAMWRDATA <= CLR;
+                                IF (CMR(6) = '0') THEN
+                                    -- IT IS LMMC
+                                    STATE <= STPRERDVRAM;
+                                ELSE
+                                    -- IT IS HMMC
+                                    STATE <= STWRVRAM;
+                                END IF;
+                            END IF;
+
+                        WHEN STWAITCPU =>
+                            -- APPLICABLE TO LMCM
+                            IF( TR  = '0' ) THEN
+                                -- CPU HAS TRANSFERRED DATA FROM (OR TO) THE COLOR REGISTER
+                                -- VDP MAY READ THE NEXT VALUE INTO THE COLOR REGISTER
+                                STATE <= STRDVRAM;
+                            END IF;
+
+                        WHEN STRDVRAM =>
+                            -- APPLICABLE TO YMMM, HMMM, LMCM, LMMM, SRCH, POINT
+                            VDPVRAMACCESSY := SY;
+                            VDPVRAMACCESSX := SXTMP(8 DOWNTO 0);
+                            RDXLOW := SXTMP(1 DOWNTO 0);
+                            VRAMRDREQ <= NOT VRAMRDACK;
+                            CASE CMR(7 DOWNTO 4) IS
+                                WHEN POINT =>
+                                    STATE <= STPOINTWAITRDVRAM;
+                                WHEN SRCH =>
+                                    STATE <= STSRCHWAITRDVRAM;
+                                WHEN OTHERS =>
+                                    STATE <= STWAITRDVRAM;
+                             END CASE;
+
+                        WHEN STPOINTWAITRDVRAM =>
+                            -- APPLICABLE TO POINT
+                            IF ( VRAMRDREQ = VRAMRDACK ) THEN
+                                CLR <= RDPOINT;
+                                STATE <= STEXECEND;
+                            END IF;
+
+                        WHEN STSRCHWAITRDVRAM =>
+                            -- APPLICABLE TO SRCH
+                            IF ( VRAMRDREQ = VRAMRDACK ) THEN
+                                IF (RDPOINT = CLR) THEN
+                                     SRCHEQRSLT := '0';
+                                 ELSE
+                                     SRCHEQRSLT := '1';
+                                 END IF;
+                                 IF (EQ = SRCHEQRSLT) THEN
+                                     BD <= '1';
+                                     STATE <= STEXECEND;
+                                 ELSE
+                                     SXTMP <= SXTMP + XCOUNTDELTA;
+                                     STATE <= STSRCHCHKLOOP;
+                                 END IF;
+                             END IF;
+
+                        WHEN STWAITRDVRAM =>
+                            -- APPLICABLE TO YMMM, HMMM, LMCM, LMMM
+                            IF ( VRAMRDREQ = VRAMRDACK ) THEN
+                                SXTMP <= SXTMP + XCOUNTDELTA;
+                                CASE CMR(7 DOWNTO 4) IS
+                                    WHEN LMMM =>
+                                        VRAMWRDATA <= RDPOINT;
+                                        STATE <= STPRERDVRAM;
+                                    WHEN LMCM =>
+                                        CLR <= RDPOINT;
+                                        TR <= '1';
+                                        NXTMP <= NXTMP - 1;
+                                        STATE <= STCHKLOOP;
+                                    WHEN OTHERS => -- REMAINING: YMMM, HMMM
+                                        VRAMWRDATA <= VRAMRDDATA;
+                                        STATE <= STWRVRAM;
+                                END CASE;
+                            END IF;
+
+                        WHEN STPRERDVRAM =>
+                            -- APPLICABLE TO LMMC, LMMM, LMMV, LINE, PSET
+                            VDPVRAMACCESSY := DY;
+                            VDPVRAMACCESSX := DXTMP(8 DOWNTO 0);
+                            RDXLOW := DXTMP(1 DOWNTO 0);
+                            VRAMRDREQ <= NOT VRAMRDACK;
+                            STATE <= STWAITPRERDVRAM;
+
+                        WHEN STWAITPRERDVRAM =>
+                            -- APPLICABLE TO LMMC, LMMM, LMMV, LINE, PSET
+                            IF ( VRAMRDREQ = VRAMRDACK ) THEN
+                                IF (GRAPHIC4_OR_6 = '1') THEN
+                                    -- SCREEN 5, 7
+                                    IF( RDXLOW(0) = '0' ) THEN
+                                        VRAMWRDATA <= LOGOPDESTCOL(3 DOWNTO 0) & VRAMRDDATA(3 DOWNTO 0);
+                                    ELSE
+                                        VRAMWRDATA <= VRAMRDDATA(7 DOWNTO 4) & LOGOPDESTCOL(3 DOWNTO 0);
+                                    END IF;
+                                ELSIF (VDPMODEGRAPHIC5 = '1') THEN
+                                    -- SCREEN 6
+                                    CASE RDXLOW IS
+                                        WHEN "00" =>
+                                            VRAMWRDATA <= LOGOPDESTCOL(1 DOWNTO 0) & VRAMRDDATA(5 DOWNTO 0);
+                                        WHEN "01" =>
+                                            VRAMWRDATA <= VRAMRDDATA(7 DOWNTO 6) & LOGOPDESTCOL(1 DOWNTO 0) & VRAMRDDATA(3 DOWNTO 0);
+                                        WHEN "10" =>
+                                            VRAMWRDATA <= VRAMRDDATA(7 DOWNTO 4) & LOGOPDESTCOL(1 DOWNTO 0) & VRAMRDDATA(1 DOWNTO 0);
+                                        WHEN OTHERS =>
+--                                      WHEN "11" =>
+                                            VRAMWRDATA <= VRAMRDDATA(7 DOWNTO 2) & LOGOPDESTCOL(1 DOWNTO 0);
+--                                      WHEN OTHERS =>
+--                                          NULL; -- SHOULD NEVER OCCUR
+                                    END CASE;
+                                ELSE
+                                    -- SCREEN 8 AND OTHER MODES
+                                    VRAMWRDATA <= LOGOPDESTCOL;
+                                END IF;
                                 STATE <= STWRVRAM;
                             END IF;
-                        END IF;
 
-                    WHEN STWAITCPU =>
-                        -- APPLICABLE TO LMCM
-                        IF( TR  = '0' ) THEN
-                            -- CPU HAS TRANSFERRED DATA FROM (OR TO) THE COLOR REGISTER
-                            -- VDP MAY READ THE NEXT VALUE INTO THE COLOR REGISTER
-                            STATE <= STRDVRAM;
-                        END IF;
+                        WHEN STWRVRAM =>
+                            -- APPLICABLE TO HMMC, YMMM, HMMM, HMMV, LMMC, LMMM, LMMV, LINE, PSET
+                            VDPVRAMACCESSY := DY;
+                            VDPVRAMACCESSX := DXTMP(8 DOWNTO 0);
+                            VRAMWRREQ <= NOT VRAMWRACK;
+                            STATE <= STWAITWRVRAM;
 
-                    WHEN STRDVRAM =>
-                        -- APPLICABLE TO YMMM, HMMM, LMCM, LMMM, SRCH, POINT
-                        VDPVRAMACCESSY := SY;
-                        VDPVRAMACCESSX := SXTMP(8 DOWNTO 0);
-                        RDXLOW := SXTMP(1 DOWNTO 0);
-                        VRAMRDREQ <= NOT VRAMRDACK;
-                        CASE CMR(7 DOWNTO 4) IS
-                            WHEN POINT =>
-                                STATE <= STPOINTWAITRDVRAM;
-                            WHEN SRCH =>
-                                STATE <= STSRCHWAITRDVRAM;
-                            WHEN OTHERS =>
-                                STATE <= STWAITRDVRAM;
-                         END CASE;
-
-                    WHEN STPOINTWAITRDVRAM =>
-                        -- APPLICABLE TO POINT
-                        IF ( VRAMRDREQ = VRAMRDACK ) THEN
-                            CLR <= RDPOINT;
-                            STATE <= STEXECEND;
-                        END IF;
-
-                    WHEN STSRCHWAITRDVRAM =>
-                        -- APPLICABLE TO SRCH
-                        IF ( VRAMRDREQ = VRAMRDACK ) THEN
-                            IF (RDPOINT = CLR) THEN
-                                 SRCHEQRSLT := '0';
-                             ELSE
-                                 SRCHEQRSLT := '1';
-                             END IF;
-                             IF (EQ = SRCHEQRSLT) THEN
-                                 BD <= '1';
-                                 STATE <= STEXECEND;
-                             ELSE
-                                 SXTMP <= SXTMP + XCOUNTDELTA;
-                                 STATE <= STSRCHCHKLOOP;
-                             END IF;
-                         END IF;
-
-                    WHEN STWAITRDVRAM =>
-                        -- APPLICABLE TO YMMM, HMMM, LMCM, LMMM
-                        IF ( VRAMRDREQ = VRAMRDACK ) THEN
-                            SXTMP <= SXTMP + XCOUNTDELTA;
-                            CASE CMR(7 DOWNTO 4) IS
-                                WHEN LMMM =>
-                                    VRAMWRDATA <= RDPOINT;
-                                    STATE <= STPRERDVRAM;
-                                WHEN LMCM =>
-                                    CLR <= RDPOINT;
-                                    TR <= '1';
-                                    NXTMP <= NXTMP - 1;
-                                    STATE <= STCHKLOOP;
-                                WHEN OTHERS => -- REMAINING: YMMM, HMMM
-                                    VRAMWRDATA <= VRAMRDDATA;
-                                    STATE <= STWRVRAM;
-                            END CASE;
-                        END IF;
-
-                    WHEN STPRERDVRAM =>
-                        -- APPLICABLE TO LMMC, LMMM, LMMV, LINE, PSET
-                        VDPVRAMACCESSY := DY;
-                        VDPVRAMACCESSX := DXTMP(8 DOWNTO 0);
-                        RDXLOW := DXTMP(1 DOWNTO 0);
-                        VRAMRDREQ <= NOT VRAMRDACK;
-                        STATE <= STWAITPRERDVRAM;
-
-                    WHEN STWAITPRERDVRAM =>
-                        -- APPLICABLE TO LMMC, LMMM, LMMV, LINE, PSET
-                        IF ( VRAMRDREQ = VRAMRDACK ) THEN
-                            IF (GRAPHIC4_OR_6 = '1') THEN
-                                -- SCREEN 5, 7
-                                IF( RDXLOW(0) = '0' ) THEN
-                                    VRAMWRDATA <= LOGOPDESTCOL(3 DOWNTO 0) & VRAMRDDATA(3 DOWNTO 0);
-                                ELSE
-                                    VRAMWRDATA <= VRAMRDDATA(7 DOWNTO 4) & LOGOPDESTCOL(3 DOWNTO 0);
-                                END IF;
-                            ELSIF (VDPMODEGRAPHIC5 = '1') THEN
-                                -- SCREEN 6
-                                CASE RDXLOW IS
-                                    WHEN "00" =>
-                                        VRAMWRDATA <= LOGOPDESTCOL(1 DOWNTO 0) & VRAMRDDATA(5 DOWNTO 0);
-                                    WHEN "01" =>
-                                        VRAMWRDATA <= VRAMRDDATA(7 DOWNTO 6) & LOGOPDESTCOL(1 DOWNTO 0) & VRAMRDDATA(3 DOWNTO 0);
-                                    WHEN "10" =>
-                                        VRAMWRDATA <= VRAMRDDATA(7 DOWNTO 4) & LOGOPDESTCOL(1 DOWNTO 0) & VRAMRDDATA(1 DOWNTO 0);
+                        WHEN STWAITWRVRAM =>
+                            -- APPLICABLE TO HMMC, YMMM, HMMM, HMMV, LMMC, LMMM, LMMV, LINE, PSET
+                            IF ( VRAMWRREQ = VRAMWRACK ) THEN
+                                CASE CMR(7 DOWNTO 4) IS
+                                    WHEN PSET =>
+                                        STATE <= STEXECEND;
+                                    WHEN LINE =>
+                                        SXTMP <= SXTMP - NY;
+                                        IF MM = '0' THEN
+                                            DXTMP <= DXTMP + XCOUNTDELTA(9 DOWNTO 0);
+                                        ELSE
+                                            DY <= DY + YCOUNTDELTA;
+                                        END IF;
+                                        STATE <= STLINENEWPOS;
                                     WHEN OTHERS =>
---                                  WHEN "11" =>
-                                        VRAMWRDATA <= VRAMRDDATA(7 DOWNTO 2) & LOGOPDESTCOL(1 DOWNTO 0);
---                                  WHEN OTHERS =>
---                                      NULL; -- SHOULD NEVER OCCUR
-                                END CASE;
-                            ELSE
-                                -- SCREEN 8 AND OTHER MODES
-                                VRAMWRDATA <= LOGOPDESTCOL;
-                            END IF;
-                            STATE <= STWRVRAM;
-                        END IF;
-
-                    WHEN STWRVRAM =>
-                        -- APPLICABLE TO HMMC, YMMM, HMMM, HMMV, LMMC, LMMM, LMMV, LINE, PSET
-                        VDPVRAMACCESSY := DY;
-                        VDPVRAMACCESSX := DXTMP(8 DOWNTO 0);
-                        VRAMWRREQ <= NOT VRAMWRACK;
-                        STATE <= STWAITWRVRAM;
-
-                    WHEN STWAITWRVRAM =>
-                        -- APPLICABLE TO HMMC, YMMM, HMMM, HMMV, LMMC, LMMM, LMMV, LINE, PSET
-                        IF ( VRAMWRREQ = VRAMWRACK ) THEN
-                            CASE CMR(7 DOWNTO 4) IS
-                                WHEN PSET =>
-                                    STATE <= STEXECEND;
-                                WHEN LINE =>
-                                    SXTMP <= SXTMP - NY;
-                                    IF MM = '0' THEN
                                         DXTMP <= DXTMP + XCOUNTDELTA(9 DOWNTO 0);
-                                    ELSE
-                                        DY <= DY + YCOUNTDELTA;
-                                    END IF;
-                                    STATE <= STLINENEWPOS;
-                                WHEN OTHERS =>
+                                        NXTMP <= NXTMP - 1;
+                                        STATE <= STCHKLOOP;
+                                END CASE;
+                            END IF;
+
+                        WHEN STLINENEWPOS =>
+                            -- APPLICABLE TO LINE
+                            IF (SXTMP(10) = '1') THEN
+                                SXTMP <= '0' & (SXTMP(9 DOWNTO 0) + NX);
+                                IF (MM = '0') THEN
+                                    DY <= DY + YCOUNTDELTA;
+                                ELSE
                                     DXTMP <= DXTMP + XCOUNTDELTA(9 DOWNTO 0);
-                                    NXTMP <= NXTMP - 1;
-                                    STATE <= STCHKLOOP;
-                            END CASE;
-                        END IF;
+                                END IF;
+                            END IF;
+                            STATE <= STLINECHKLOOP;
 
-                    WHEN STLINENEWPOS =>
-                        -- APPLICABLE TO LINE
-                        IF (SXTMP(10) = '1') THEN
-                            SXTMP <= '0' & (SXTMP(9 DOWNTO 0) + NX);
-                            IF (MM = '0') THEN
-                                DY <= DY + YCOUNTDELTA;
+                        WHEN STLINECHKLOOP =>
+                            -- APPLICABLE TO LINE
+                            IF ((NXTMP = NX) OR
+                                    ((DXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK)) THEN
+                                STATE <= STEXECEND;
                             ELSE
-                                DXTMP <= DXTMP + XCOUNTDELTA(9 DOWNTO 0);
+                                VRAMWRDATA <= CLR;
+                                -- COLOR MUST BE RE-MASKED, JUST IN CASE THAT SCREENMODE WAS CHANGED
+                                CLR <= CLR AND COLMASK;
+                                STATE <= STPRERDVRAM;
                             END IF;
-                        END IF;
-                        STATE <= STLINECHKLOOP;
+                            NXTMP <= NXTMP + 1;
 
-                    WHEN STLINECHKLOOP =>
-                        -- APPLICABLE TO LINE
-                        IF ((NXTMP = NX) OR
-                                ((DXTMP(9 DOWNTO 8) AND MAXXMASK) = MAXXMASK)) THEN
-                            STATE <= STEXECEND;
-                        ELSE
-                            VRAMWRDATA <= CLR;
-                            -- COLOR MUST BE RE-MASKED, JUST IN CASE THAT SCREENMODE WAS CHANGED
-                            CLR <= CLR AND COLMASK;
-                            STATE <= STPRERDVRAM;
-                        END IF;
-                        NXTMP <= NXTMP + 1;
-
-                    WHEN STSRCHCHKLOOP =>
-                        -- APPLICABLE TO SRCH
-                        IF (NXLOOPEND = '1') THEN
-                            STATE <= STEXECEND;
-                        ELSE
-                            -- COLOR MUST BE RE-MASKED, JUST IN CASE THAT SCREENMODE WAS CHANGED
-                            CLR <= CLR AND COLMASK;
-                            STATE <= STRDVRAM;
-                        END IF;
-
-                    WHEN STCHKLOOP =>
-                        -- WHEN INITIALIZING = '1':
-                        --   APPLICABLE TO ALL COMMANDS
-                        -- WHEN INITIALIZING = '0':
-                        -- APPLICABLE TO HMMC, YMMM, HMMM, HMMV, LMMC, LMCM, LMMM, LMMV
-
-                        -- DETERMINE NYLOOPEND
-                        DYEND := '0';
-                        SYEND := '0';
-                        IF (DIY = '1') THEN
-                            IF ((DY = 0) AND (CMR(7 DOWNTO 4) /= LMCM)) THEN
-                                DYEND := '1';
-                            END IF;
-                            IF ((SY = 0) AND (CMR(5) /= CMR(4))) THEN
-                                -- BIT5 /= BIT4 IS TRUE FOR COMMANDS YMMM, HMMM, LMCM, LMMM
-                                SYEND := '1';
-                            END IF;
-                        END IF;
-                        IF ((NY = 1) OR (DYEND = '1') OR (SYEND = '1')) THEN
-                            NYLOOPEND := '1';
-                        ELSE
-                            NYLOOPEND := '0';
-                        END IF;
-
-                        IF ((INITIALIZING = '0') AND (NXLOOPEND = '1') AND (NYLOOPEND = '1')) THEN
-                            STATE <= STEXECEND;
-                        ELSE
-                            -- COMMAND NOT YET FINISHED OR COMMAND INITIALIZING. DETERMINE NEXT/FIRST STEP
-                            -- COLOR MUST BE (RE-)MASKED, JUST IN CASE THAT SCREENMODE WAS CHANGED
-                            CLR <= CLR AND COLMASK;
-                            CASE CMR(7 DOWNTO 4) IS
-                                WHEN HMMC =>
-                                    STATE <= STRDCPU;
-                                WHEN YMMM =>
-                                    STATE <= STRDVRAM;
-                                WHEN HMMM =>
-                                    STATE <= STRDVRAM;
-                                WHEN HMMV =>
-                                    VRAMWRDATA <= CLR;
-                                    STATE <= STWRVRAM;
-                                WHEN LMMC =>
-                                    STATE <= STRDCPU;
-                                WHEN LMCM =>
-                                    STATE <= STWAITCPU;
-                                WHEN LMMM =>
-                                    STATE <= STRDVRAM;
-                                WHEN LMMV | LINE | PSET =>
-                                    VRAMWRDATA <= CLR;
-                                    STATE <= STPRERDVRAM;
-                                WHEN SRCH =>
-                                    STATE <= STRDVRAM;
-                                WHEN POINT =>
-                                    STATE <= STRDVRAM;
-                                WHEN OTHERS =>
-                                    STATE <= STEXECEND;
-                            END CASE;
-                        END IF;
-                        IF( (INITIALIZING = '0') AND (NXLOOPEND = '1') ) THEN
-                            NXTMP <= NXCOUNT;
-                            IF CMR(7 DOWNTO 4) = YMMM THEN
-                                SXTMP <= "00" & DX;
+                        WHEN STSRCHCHKLOOP =>
+                            -- APPLICABLE TO SRCH
+                            IF (NXLOOPEND = '1') THEN
+                                STATE <= STEXECEND;
                             ELSE
-                                SXTMP <= "00" & SX;
+                                -- COLOR MUST BE RE-MASKED, JUST IN CASE THAT SCREENMODE WAS CHANGED
+                                CLR <= CLR AND COLMASK;
+                                STATE <= STRDVRAM;
                             END IF;
-                            DXTMP <= '0' & DX;
-                            NY <= NY - 1;
-                            IF (CMR(5) /= CMR(4)) THEN
-                                -- BIT5 /= BIT4 IS TRUE FOR COMMANDS YMMM, HMMM, LMCM, LMMM
-                                SY <= SY + YCOUNTDELTA;
-                            END IF;
-                            IF (CMR(7 DOWNTO 4) /= LMCM) THEN
-                                DY <= DY + YCOUNTDELTA;
-                            END IF;
-                        ELSE
-                            SXTMP(10) <= '0';
-                        END IF;
-                        INITIALIZING := '0';
-                    WHEN OTHERS =>
-                        STATE <= STIDLE;
-                        CE <= '0';
-                        CMR <= (OTHERS => '0');
-                END CASE;
-            END IF;
 
-            IF( VDPMODEGRAPHIC4 = '1' )THEN
-                VRAMACCESSADDR <= VDPVRAMACCESSY(9 DOWNTO 0) & VDPVRAMACCESSX(7 DOWNTO 1);
-            ELSIF( VDPMODEGRAPHIC5  = '1' )THEN
-                VRAMACCESSADDR <= VDPVRAMACCESSY(9 DOWNTO 0) & VDPVRAMACCESSX(8 DOWNTO 2);
-            ELSIF( VDPMODEGRAPHIC6  = '1' )THEN
-                VRAMACCESSADDR <= VDPVRAMACCESSY(8 DOWNTO 0) & VDPVRAMACCESSX(8 DOWNTO 1);
-            ELSE
-                VRAMACCESSADDR <= VDPVRAMACCESSY(8 DOWNTO 0) & VDPVRAMACCESSX(7 DOWNTO 0);
-            END IF;
+                        WHEN STCHKLOOP =>
+                            -- WHEN INITIALIZING = '1':
+                            --   APPLICABLE TO ALL COMMANDS
+                            -- WHEN INITIALIZING = '0':
+                            -- APPLICABLE TO HMMC, YMMM, HMMM, HMMV, LMMC, LMCM, LMMM, LMMV
 
+                            -- DETERMINE NYLOOPEND
+                            DYEND := '0';
+                            SYEND := '0';
+                            IF (DIY = '1') THEN
+                                IF ((DY = 0) AND (CMR(7 DOWNTO 4) /= LMCM)) THEN
+                                    DYEND := '1';
+                                END IF;
+                                IF ((SY = 0) AND (CMR(5) /= CMR(4))) THEN
+                                    -- BIT5 /= BIT4 IS TRUE FOR COMMANDS YMMM, HMMM, LMCM, LMMM
+                                    SYEND := '1';
+                                END IF;
+                            END IF;
+                            IF ((NY = 1) OR (DYEND = '1') OR (SYEND = '1')) THEN
+                                NYLOOPEND := '1';
+                            ELSE
+                                NYLOOPEND := '0';
+                            END IF;
+
+                            IF ((INITIALIZING = '0') AND (NXLOOPEND = '1') AND (NYLOOPEND = '1')) THEN
+                                STATE <= STEXECEND;
+                            ELSE
+                                -- COMMAND NOT YET FINISHED OR COMMAND INITIALIZING. DETERMINE NEXT/FIRST STEP
+                                -- COLOR MUST BE (RE-)MASKED, JUST IN CASE THAT SCREENMODE WAS CHANGED
+                                CLR <= CLR AND COLMASK;
+                                CASE CMR(7 DOWNTO 4) IS
+                                    WHEN HMMC =>
+                                        STATE <= STRDCPU;
+                                    WHEN YMMM =>
+                                        STATE <= STRDVRAM;
+                                    WHEN HMMM =>
+                                        STATE <= STRDVRAM;
+                                    WHEN HMMV =>
+                                        VRAMWRDATA <= CLR;
+                                        STATE <= STWRVRAM;
+                                    WHEN LMMC =>
+                                        STATE <= STRDCPU;
+                                    WHEN LMCM =>
+                                        STATE <= STWAITCPU;
+                                    WHEN LMMM =>
+                                        STATE <= STRDVRAM;
+                                    WHEN LMMV | LINE | PSET =>
+                                        VRAMWRDATA <= CLR;
+                                        STATE <= STPRERDVRAM;
+                                    WHEN SRCH =>
+                                        STATE <= STRDVRAM;
+                                    WHEN POINT =>
+                                        STATE <= STRDVRAM;
+                                    WHEN OTHERS =>
+                                        STATE <= STEXECEND;
+                                END CASE;
+                            END IF;
+                            IF( (INITIALIZING = '0') AND (NXLOOPEND = '1') ) THEN
+                                NXTMP <= NXCOUNT;
+                                IF CMR(7 DOWNTO 4) = YMMM THEN
+                                    SXTMP <= "00" & DX;
+                                ELSE
+                                    SXTMP <= "00" & SX;
+                                END IF;
+                                DXTMP <= '0' & DX;
+                                NY <= NY - 1;
+                                IF (CMR(5) /= CMR(4)) THEN
+                                    -- BIT5 /= BIT4 IS TRUE FOR COMMANDS YMMM, HMMM, LMCM, LMMM
+                                    SY <= SY + YCOUNTDELTA;
+                                END IF;
+                                IF (CMR(7 DOWNTO 4) /= LMCM) THEN
+                                    DY <= DY + YCOUNTDELTA;
+                                END IF;
+                            ELSE
+                                SXTMP(10) <= '0';
+                            END IF;
+                            INITIALIZING := '0';
+                        WHEN OTHERS =>
+                            STATE <= STIDLE;
+                            CE <= '0';
+                            CMR <= (OTHERS => '0');
+                    END CASE;
+                END IF;
+
+                IF( VDPMODEGRAPHIC4 = '1' )THEN
+                    VRAMACCESSADDR <= VDPVRAMACCESSY(9 DOWNTO 0) & VDPVRAMACCESSX(7 DOWNTO 1);
+                ELSIF( VDPMODEGRAPHIC5  = '1' )THEN
+                    VRAMACCESSADDR <= VDPVRAMACCESSY(9 DOWNTO 0) & VDPVRAMACCESSX(8 DOWNTO 2);
+                ELSIF( VDPMODEGRAPHIC6  = '1' )THEN
+                    VRAMACCESSADDR <= VDPVRAMACCESSY(8 DOWNTO 0) & VDPVRAMACCESSX(8 DOWNTO 1);
+                ELSE
+                    VRAMACCESSADDR <= VDPVRAMACCESSY(8 DOWNTO 0) & VDPVRAMACCESSX(7 DOWNTO 0);
+                END IF;
+
+            END IF;
         END IF;
     END PROCESS;
 END RTL;

--- a/VIDEO/vdp_graphic123m.vhd
+++ b/VIDEO/vdp_graphic123m.vhd
@@ -173,79 +173,93 @@ BEGIN
     -- FF
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_PAT_COL <= ( OTHERS => '0' );
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "00" AND EIGHTDOTSTATE_DEC(0) = '1' )THEN
-                FF_PAT_COL <= FF_PRE_PAT_COL;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FF_PAT_COL <= ( OTHERS => '0' );
+	    ELSE
+                IF( DOTSTATE = "00" AND EIGHTDOTSTATE_DEC(0) = '1' )THEN
+                    FF_PAT_COL <= FF_PRE_PAT_COL;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_PAT_GEN <= ( OTHERS => '0' );
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "00" AND EIGHTDOTSTATE_DEC(0) = '1' )THEN
-                FF_PAT_GEN <= FF_PRE_PAT_GEN;
-            ELSIF( DOTSTATE = "01" )THEN
-                FF_PAT_GEN <= FF_PAT_GEN( 6 DOWNTO 0 ) & '0';
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FF_PAT_GEN <= ( OTHERS => '0' );
+	    ELSE
+                IF( DOTSTATE = "00" AND EIGHTDOTSTATE_DEC(0) = '1' )THEN
+                    FF_PAT_GEN <= FF_PRE_PAT_GEN;
+                ELSIF( DOTSTATE = "01" )THEN
+                    FF_PAT_GEN <= FF_PAT_GEN( 6 DOWNTO 0 ) & '0';
+                END IF;
             END IF;
         END IF;
     END PROCESS;
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_PAT_NUM <= ( OTHERS => '0' );
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "01" AND EIGHTDOTSTATE_DEC(1) = '1' )THEN
-                FF_PAT_NUM <= PRAMDAT;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FF_PAT_NUM <= ( OTHERS => '0' );
+	    ELSE
+                IF( DOTSTATE = "01" AND EIGHTDOTSTATE_DEC(1) = '1' )THEN
+                    FF_PAT_NUM <= PRAMDAT;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_PRE_PAT_GEN <= ( OTHERS => '0' );
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "01" AND EIGHTDOTSTATE_DEC(2) = '1' )THEN
-                FF_PRE_PAT_GEN <= PRAMDAT;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FF_PRE_PAT_GEN <= ( OTHERS => '0' );
+	    ELSE
+                IF( DOTSTATE = "01" AND EIGHTDOTSTATE_DEC(2) = '1' )THEN
+                    FF_PRE_PAT_GEN <= PRAMDAT;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_PRE_PAT_COL <= ( OTHERS => '0' );
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "01" AND EIGHTDOTSTATE_DEC(3) = '1' )THEN
-                FF_PRE_PAT_COL <= PRAMDAT;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FF_PRE_PAT_COL <= ( OTHERS => '0' );
+	    ELSE
+                IF( DOTSTATE = "01" AND EIGHTDOTSTATE_DEC(3) = '1' )THEN
+                    FF_PRE_PAT_COL <= PRAMDAT;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_COL_CODE <= ( OTHERS => '0' );
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "01" )THEN
-                FF_COL_CODE <= COL_CODE;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FF_COL_CODE <= ( OTHERS => '0' );
+	    ELSE
+                IF( DOTSTATE = "01" )THEN
+                    FF_COL_CODE <= COL_CODE;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_REQ_ADDR <= ( OTHERS => '0' );
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "11" )THEN
-                FF_REQ_ADDR <= REQ_ADDR;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FF_REQ_ADDR <= ( OTHERS => '0' );
+	    ELSE
+                IF( DOTSTATE = "11" )THEN
+                    FF_REQ_ADDR <= REQ_ADDR;
+                END IF;
             END IF;
         END IF;
     END PROCESS;

--- a/VIDEO/vdp_graphic4567.vhd
+++ b/VIDEO/vdp_graphic4567.vhd
@@ -244,118 +244,126 @@ BEGIN
     -- FIFO CONTROL
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FIFOADDR_IN <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "00" )THEN
-                IF( EIGHTDOTSTATE = "000" AND DOTCOUNTERX = 0 ) THEN
-                    FIFOADDR_IN <= (OTHERS => '0');
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FIFOADDR_IN <= (OTHERS => '0');
+	    ELSE
+                IF( DOTSTATE = "00" )THEN
+                    IF( EIGHTDOTSTATE = "000" AND DOTCOUNTERX = 0 ) THEN
+                        FIFOADDR_IN <= (OTHERS => '0');
+                    END IF;
+                ELSIF( FIFOIN = '1' ) THEN
+                    FIFOADDR_IN <= FIFOADDR_IN + 1;
                 END IF;
-            ELSIF( FIFOIN = '1' ) THEN
-                FIFOADDR_IN <= FIFOADDR_IN + 1;
             END IF;
         END IF;
     END PROCESS;
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FIFOADDR_OUT    <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            CASE DOTSTATE IS
-            WHEN "00" =>
-                NULL;
-            WHEN "01" =>
-                IF( (VDPMODEGRAPHIC4 = '0') AND (VDPMODEGRAPHIC5 = '0') )THEN
-                    FIFOADDR_OUT <= FIFOADDR_OUT + 1;
-                ELSIF( EIGHTDOTSTATE(0) = '0' )THEN
-                    -- GRAPHIC4, 5
-                    FIFOADDR_OUT <= FIFOADDR_OUT + 1;
-                END IF;
-            WHEN "11" =>
-                NULL;
-            WHEN "10" =>
-                IF( DOTCOUNTERX = X"04" )THEN
-                    FIFOADDR_OUT <= (OTHERS => '0');
-                END IF;
-            WHEN OTHERS =>
-                NULL;
-            END CASE;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FIFOADDR_OUT    <= (OTHERS => '0');
+	    ELSE
+                CASE DOTSTATE IS
+                WHEN "00" =>
+                    NULL;
+                WHEN "01" =>
+                    IF( (VDPMODEGRAPHIC4 = '0') AND (VDPMODEGRAPHIC5 = '0') )THEN
+                        FIFOADDR_OUT <= FIFOADDR_OUT + 1;
+                    ELSIF( EIGHTDOTSTATE(0) = '0' )THEN
+                        -- GRAPHIC4, 5
+                        FIFOADDR_OUT <= FIFOADDR_OUT + 1;
+                    END IF;
+                WHEN "11" =>
+                    NULL;
+                WHEN "10" =>
+                    IF( DOTCOUNTERX = X"04" )THEN
+                        FIFOADDR_OUT <= (OTHERS => '0');
+                    END IF;
+                WHEN OTHERS =>
+                    NULL;
+                END CASE;
+            END IF;
         END IF;
     END PROCESS;
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FIFOIN <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            CASE DOTSTATE IS
-            WHEN "00" =>
-                IF(     EIGHTDOTSTATE = "000" ) THEN
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FIFOIN <= '0';
+	    ELSE
+                CASE DOTSTATE IS
+                WHEN "00" =>
+                    IF(     EIGHTDOTSTATE = "000" ) THEN
+                        FIFOIN <= '0';
+                    ELSIF(  (EIGHTDOTSTATE = "001") OR
+                            (EIGHTDOTSTATE = "010") OR
+                            (EIGHTDOTSTATE = "011") OR
+                            (EIGHTDOTSTATE = "100") )THEN
+                        FIFOIN <= '1';
+                    END IF;
+                WHEN "01" =>
                     FIFOIN <= '0';
-                ELSIF(  (EIGHTDOTSTATE = "001") OR
-                        (EIGHTDOTSTATE = "010") OR
-                        (EIGHTDOTSTATE = "011") OR
-                        (EIGHTDOTSTATE = "100") )THEN
-                    FIFOIN <= '1';
-                END IF;
-            WHEN "01" =>
-                FIFOIN <= '0';
-            WHEN "11" =>
-                IF( ((VDPMODEGRAPHIC6 = '1') OR (VDPMODEGRAPHIC7 = '1')) AND
-                    (   (EIGHTDOTSTATE = "001") OR
-                        (EIGHTDOTSTATE = "010") OR
-                        (EIGHTDOTSTATE = "011") OR
-                        (EIGHTDOTSTATE = "100")) )THEN
-                    FIFOIN <= '1';
-                END IF;
-            WHEN "10" =>
-                FIFOIN <= '0';
-            WHEN OTHERS =>
-                NULL;
-            END CASE;
+                WHEN "11" =>
+                    IF( ((VDPMODEGRAPHIC6 = '1') OR (VDPMODEGRAPHIC7 = '1')) AND
+                        (   (EIGHTDOTSTATE = "001") OR
+                            (EIGHTDOTSTATE = "010") OR
+                            (EIGHTDOTSTATE = "011") OR
+                            (EIGHTDOTSTATE = "100")) )THEN
+                        FIFOIN <= '1';
+                    END IF;
+                WHEN "10" =>
+                    FIFOIN <= '0';
+                WHEN OTHERS =>
+                    NULL;
+                END CASE;
+            END IF;
         END IF;
     END PROCESS;
 
     -- FIFO OUT LATCH
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            COLORDATA   <= (OTHERS => '0');
-            PCOLORCODE  <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            CASE DOTSTATE IS
-            WHEN "00" =>
-                NULL;
-            WHEN "01" =>
-                IF( (VDPMODEGRAPHIC4 = '1') OR (VDPMODEGRAPHIC5 = '1') )THEN
-                    IF( EIGHTDOTSTATE(0) = '0' )THEN
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                COLORDATA   <= (OTHERS => '0');
+                PCOLORCODE  <= (OTHERS => '0');
+	    ELSE
+                CASE DOTSTATE IS
+                WHEN "00" =>
+                    NULL;
+                WHEN "01" =>
+                    IF( (VDPMODEGRAPHIC4 = '1') OR (VDPMODEGRAPHIC5 = '1') )THEN
+                        IF( EIGHTDOTSTATE(0) = '0' )THEN
+                            COLORDATA <= W_PIX;
+                            PCOLORCODE( 7 DOWNTO 4 ) <= (OTHERS => '0');
+                            PCOLORCODE( 3 DOWNTO 0 ) <= W_PIX( 7 DOWNTO 4 );
+                        ELSE
+                            PCOLORCODE( 7 DOWNTO 4 ) <= (OTHERS => '0');
+                            PCOLORCODE( 3 DOWNTO 0 ) <= COLORDATA( 3 DOWNTO 0 );
+                        END IF;
+                    ELSIF( VDPMODEGRAPHIC6 = '1' OR REG_R25_YAE = '1' )THEN
                         COLORDATA <= W_PIX;
                         PCOLORCODE( 7 DOWNTO 4 ) <= (OTHERS => '0');
                         PCOLORCODE( 3 DOWNTO 0 ) <= W_PIX( 7 DOWNTO 4 );
                     ELSE
+                        -- GRAPHIC7
+                        PCOLORCODE <= W_PIX;
+                    END IF;
+                WHEN "11" =>
+                    NULL;
+                WHEN "10" =>
+                    -- HIGH RESOLUTION MODE .
+                    IF( VDPMODEGRAPHIC6 = '1' )THEN
                         PCOLORCODE( 7 DOWNTO 4 ) <= (OTHERS => '0');
                         PCOLORCODE( 3 DOWNTO 0 ) <= COLORDATA( 3 DOWNTO 0 );
                     END IF;
-                ELSIF( VDPMODEGRAPHIC6 = '1' OR REG_R25_YAE = '1' )THEN
-                    COLORDATA <= W_PIX;
-                    PCOLORCODE( 7 DOWNTO 4 ) <= (OTHERS => '0');
-                    PCOLORCODE( 3 DOWNTO 0 ) <= W_PIX( 7 DOWNTO 4 );
-                ELSE
-                    -- GRAPHIC7
-                    PCOLORCODE <= W_PIX;
-                END IF;
-            WHEN "11" =>
-                NULL;
-            WHEN "10" =>
-                -- HIGH RESOLUTION MODE .
-                IF( VDPMODEGRAPHIC6 = '1' )THEN
-                    PCOLORCODE( 7 DOWNTO 4 ) <= (OTHERS => '0');
-                    PCOLORCODE( 3 DOWNTO 0 ) <= COLORDATA( 3 DOWNTO 0 );
-                END IF;
-            WHEN OTHERS =>
-                NULL;
-            END CASE;
+                WHEN OTHERS =>
+                    NULL;
+                END CASE;
+            END IF;
         END IF;
     END PROCESS;
 
@@ -383,30 +391,34 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            P_YJK_R <=  (OTHERS => '0');
-            P_YJK_G <=  (OTHERS => '0');
-            P_YJK_B <=  (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "01" )THEN
-                P_YJK_R <= W_R;
-                P_YJK_G <= W_G;
-                P_YJK_B <= W_B;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                P_YJK_R <=  (OTHERS => '0');
+                P_YJK_G <=  (OTHERS => '0');
+                P_YJK_B <=  (OTHERS => '0');
+	    ELSE
+                IF( DOTSTATE = "01" )THEN
+                    P_YJK_R <= W_R;
+                    P_YJK_G <= W_G;
+                    P_YJK_B <= W_B;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            P_YJK_EN <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "01" )THEN
-                IF( REG_R25_YAE = '1' AND W_PIX(3) = '1' )THEN
-                    -- PALETTE COLOR ON SCREEN10/SCREEN11
-                    P_YJK_EN <= '0';
-                ELSE
-                    P_YJK_EN <= REG_R25_YJK;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                P_YJK_EN <= '0';
+	    ELSE
+                IF( DOTSTATE = "01" )THEN
+                    IF( REG_R25_YAE = '1' AND W_PIX(3) = '1' )THEN
+                        -- PALETTE COLOR ON SCREEN10/SCREEN11
+                        P_YJK_EN <= '0';
+                    ELSE
+                        P_YJK_EN <= REG_R25_YJK;
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -415,14 +427,16 @@ BEGIN
     -- VRAM READ ADDRESS
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            PRAMADR <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "11" )THEN
-                IF( (VDPMODEGRAPHIC4 = '1') OR (VDPMODEGRAPHIC5 = '1') ) THEN
-                    PRAMADR <= LOGICALVRAMADDRG45( 16 DOWNTO 0 );
-                ELSE
-                    PRAMADR <= LOGICALVRAMADDRG67(0) & LOGICALVRAMADDRG67( 16 DOWNTO 1 );
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                PRAMADR <= (OTHERS => '0');
+	    ELSE
+                IF( DOTSTATE = "11" )THEN
+                    IF( (VDPMODEGRAPHIC4 = '1') OR (VDPMODEGRAPHIC5 = '1') ) THEN
+                        PRAMADR <= LOGICALVRAMADDRG45( 16 DOWNTO 0 );
+                    ELSE
+                        PRAMADR <= LOGICALVRAMADDRG67(0) & LOGICALVRAMADDRG67( 16 DOWNTO 1 );
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -430,11 +444,13 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            LATCHEDPTNNAMETBLBASEADDR   <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "00" AND EIGHTDOTSTATE = "000" )THEN
-                LATCHEDPTNNAMETBLBASEADDR <= REG_R2_PT_NAM_ADDR;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                LATCHEDPTNNAMETBLBASEADDR   <= (OTHERS => '0');
+	    ELSE
+                IF( DOTSTATE = "00" AND EIGHTDOTSTATE = "000" )THEN
+                    LATCHEDPTNNAMETBLBASEADDR <= REG_R2_PT_NAM_ADDR;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -443,17 +459,19 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            LOCALDOTCOUNTERX <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "00" )THEN
-                IF( EIGHTDOTSTATE = "000" ) THEN
-                    LOCALDOTCOUNTERX <= W_DOTCOUNTERX;
-                ELSIF(  (EIGHTDOTSTATE = "001") OR
-                        (EIGHTDOTSTATE = "010") OR
-                        (EIGHTDOTSTATE = "011") OR
-                        (EIGHTDOTSTATE = "100") ) THEN
-                    LOCALDOTCOUNTERX <= LOCALDOTCOUNTERX + 2;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                LOCALDOTCOUNTERX <= (OTHERS => '0');
+	    ELSE
+                IF( DOTSTATE = "00" )THEN
+                    IF( EIGHTDOTSTATE = "000" ) THEN
+                        LOCALDOTCOUNTERX <= W_DOTCOUNTERX;
+                    ELSIF(  (EIGHTDOTSTATE = "001") OR
+                            (EIGHTDOTSTATE = "010") OR
+                            (EIGHTDOTSTATE = "011") OR
+                            (EIGHTDOTSTATE = "100") ) THEN
+                        LOCALDOTCOUNTERX <= LOCALDOTCOUNTERX + 2;
+                    END IF;
                 END IF;
             END IF;
         END IF;

--- a/VIDEO/vdp_hvcounter.vhd
+++ b/VIDEO/vdp_hvcounter.vhd
@@ -119,13 +119,15 @@ BEGIN
     --------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_PAL_MODE         <= '0';
-            FF_INTERLACE_MODE   <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( ((W_H_CNT_HALF OR W_H_CNT_END) AND W_FIELD_END AND FF_FIELD) = '1' )THEN
-                FF_PAL_MODE         <= PAL_MODE;
-                FF_INTERLACE_MODE   <= INTERLACE_MODE;
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_PAL_MODE         <= '0';
+                FF_INTERLACE_MODE   <= '0';
+            ELSE
+                IF( ((W_H_CNT_HALF OR W_H_CNT_END) AND W_FIELD_END AND FF_FIELD) = '1' )THEN
+                    FF_PAL_MODE         <= PAL_MODE;
+                    FF_INTERLACE_MODE   <= INTERLACE_MODE;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -140,13 +142,15 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_H_CNT <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( W_H_CNT_END = '1' )THEN
-                FF_H_CNT <= (OTHERS => '0' );
-            ELSE
-                FF_H_CNT <= FF_H_CNT + 1;
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_H_CNT <= (OTHERS => '0');
+	    else
+                IF( W_H_CNT_END = '1' )THEN
+                    FF_H_CNT <= (OTHERS => '0' );
+                ELSE
+                    FF_H_CNT <= FF_H_CNT + 1;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -168,14 +172,16 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_V_CNT_IN_FIELD   <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( (W_H_CNT_HALF OR W_H_CNT_END) = '1' )THEN
-                IF( W_FIELD_END = '1' )THEN
-                    FF_V_CNT_IN_FIELD <= (OTHERS => '0');
-                ELSE
-                    FF_V_CNT_IN_FIELD <= FF_V_CNT_IN_FIELD + 1;
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_V_CNT_IN_FIELD   <= (OTHERS => '0');
+	    else
+                IF( (W_H_CNT_HALF OR W_H_CNT_END) = '1' )THEN
+                    IF( W_FIELD_END = '1' )THEN
+                        FF_V_CNT_IN_FIELD <= (OTHERS => '0');
+                    ELSE
+                        FF_V_CNT_IN_FIELD <= FF_V_CNT_IN_FIELD + 1;
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -186,13 +192,15 @@ BEGIN
     --------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_FIELD <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            -- GENERATE FF_FIELD SIGNAL
-            IF( (W_H_CNT_HALF OR W_H_CNT_END) = '1' )THEN
-                IF( W_FIELD_END = '1' )THEN
-                    FF_FIELD <= NOT FF_FIELD;
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_FIELD <= '0';
+	    else
+                -- GENERATE FF_FIELD SIGNAL
+                IF( (W_H_CNT_HALF OR W_H_CNT_END) = '1' )THEN
+                    IF( W_FIELD_END = '1' )THEN
+                        FF_FIELD <= NOT FF_FIELD;
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -203,14 +211,16 @@ BEGIN
     --------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_V_CNT_IN_FRAME   <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( (W_H_CNT_HALF OR W_H_CNT_END) = '1' )THEN
-                IF( W_FIELD_END = '1' AND FF_FIELD = '1' )THEN
-                    FF_V_CNT_IN_FRAME   <= (OTHERS => '0');
-                ELSE
-                    FF_V_CNT_IN_FRAME   <= FF_V_CNT_IN_FRAME + 1;
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_V_CNT_IN_FRAME   <= (OTHERS => '0');
+	    ELSE
+                IF( (W_H_CNT_HALF OR W_H_CNT_END) = '1' )THEN
+                    IF( W_FIELD_END = '1' AND FF_FIELD = '1' )THEN
+                        FF_V_CNT_IN_FRAME   <= (OTHERS => '0');
+                    ELSE
+                        FF_V_CNT_IN_FRAME   <= FF_V_CNT_IN_FRAME + 1;
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -225,13 +235,15 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_H_BLANK <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( W_H_BLANK_START = '1' )THEN
-                FF_H_BLANK <= '1';
-            ELSIF( W_H_BLANK_END = '1' )THEN
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
                 FF_H_BLANK <= '0';
+	    ELSE
+                IF( W_H_BLANK_START = '1' )THEN
+                    FF_H_BLANK <= '1';
+                ELSIF( W_H_BLANK_END = '1' )THEN
+                    FF_H_BLANK <= '0';
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -257,14 +269,16 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_V_BLANK <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( W_H_BLANK_END = '1' )THEN
-                IF( W_V_BLANKING_END = '1' )THEN
-                    FF_V_BLANK <= '0';
-                ELSIF( W_V_BLANKING_START = '1' )THEN
-                    FF_V_BLANK <= '1';
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_V_BLANK <= '0';
+	    ELSE
+                IF( W_H_BLANK_END = '1' )THEN
+                    IF( W_V_BLANKING_END = '1' )THEN
+                        FF_V_BLANK <= '0';
+                    ELSIF( W_V_BLANKING_START = '1' )THEN
+                        FF_V_BLANK <= '1';
+                    END IF;
                 END IF;
             END IF;
         END IF;

--- a/VIDEO/vdp_interrupt.vhd
+++ b/VIDEO/vdp_interrupt.vhd
@@ -97,15 +97,17 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_VSYNC_INT_N <= '1';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( CLR_VSYNC_INT = '1' )THEN
-                -- V-BLANKING INTERRUPT CLEAR
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
                 FF_VSYNC_INT_N <= '1';
-            ELSIF( W_VSYNC_INTR_TIMING = '1' AND V_BLANKING_START = '1' )THEN
-                -- V-BLANKING INTERRUPT REQUEST
-                FF_VSYNC_INT_N <= '0';
+	    ELSE
+                IF( CLR_VSYNC_INT = '1' )THEN
+                    -- V-BLANKING INTERRUPT CLEAR
+                    FF_VSYNC_INT_N <= '1';
+                ELSIF( W_VSYNC_INTR_TIMING = '1' AND V_BLANKING_START = '1' )THEN
+                    -- V-BLANKING INTERRUPT REQUEST
+                    FF_VSYNC_INT_N <= '0';
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -115,15 +117,17 @@ BEGIN
     --------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF (RESET = '1') THEN
-            FF_HSYNC_INT_N <= '1';
-        ELSIF (CLK21M'EVENT AND CLK21M = '1') THEN
-            IF( CLR_HSYNC_INT = '1' OR (W_VSYNC_INTR_TIMING = '1' AND V_BLANKING_START = '1') )THEN
-                -- H-BLANKING INTERRUPT CLEAR
+        IF (CLK21M'EVENT AND CLK21M = '1') THEN
+            IF (RESET = '1') THEN
                 FF_HSYNC_INT_N <= '1';
-            ELSIF( ACTIVE_LINE = '1' AND Y_CNT = REG_R19_HSYNC_INT_LINE )THEN
-                -- H-BLANKING INTERRUPT REQUEST
-                FF_HSYNC_INT_N <= '0';
+	    ELSE
+                IF( CLR_HSYNC_INT = '1' OR (W_VSYNC_INTR_TIMING = '1' AND V_BLANKING_START = '1') )THEN
+                    -- H-BLANKING INTERRUPT CLEAR
+                    FF_HSYNC_INT_N <= '1';
+                ELSIF( ACTIVE_LINE = '1' AND Y_CNT = REG_R19_HSYNC_INT_LINE )THEN
+                    -- H-BLANKING INTERRUPT REQUEST
+                    FF_HSYNC_INT_N <= '0';
+                END IF;
             END IF;
         END IF;
     END PROCESS;

--- a/VIDEO/vdp_ntsc_pal.vhd
+++ b/VIDEO/vdp_ntsc_pal.vhd
@@ -161,20 +161,22 @@ BEGIN
     -- STATE
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF (RESET = '1') THEN
-            FF_SSTATE <= SSTATE_A;
-        ELSIF (CLK21M'EVENT AND CLK21M = '1') THEN
-            IF(     (VCOUNTERIN = 0) OR
-                    (VCOUNTERIN = 12) OR
-                    (VCOUNTERIN = W_STATE_A1_FULL) OR
-                    (VCOUNTERIN = W_STATE_A2_FULL) )THEN
+        IF (CLK21M'EVENT AND CLK21M = '1') THEN
+            IF (RESET = '1') THEN
                 FF_SSTATE <= SSTATE_A;
-            ELSIF(  (VCOUNTERIN = 6) OR
-                    (VCOUNTERIN = W_STATE_B_FULL) )THEN
-                FF_SSTATE <= SSTATE_B;
-            ELSIF(  (VCOUNTERIN = 18) OR
-                    (VCOUNTERIN = W_STATE_C_FULL) )THEN
-                FF_SSTATE <= SSTATE_C;
+	    ELSE
+                IF(     (VCOUNTERIN = 0) OR
+                        (VCOUNTERIN = 12) OR
+                        (VCOUNTERIN = W_STATE_A1_FULL) OR
+                        (VCOUNTERIN = W_STATE_A2_FULL) )THEN
+                    FF_SSTATE <= SSTATE_A;
+                ELSIF(  (VCOUNTERIN = 6) OR
+                        (VCOUNTERIN = W_STATE_B_FULL) )THEN
+                    FF_SSTATE <= SSTATE_B;
+                ELSIF(  (VCOUNTERIN = 18) OR
+                        (VCOUNTERIN = W_STATE_C_FULL) )THEN
+                    FF_SSTATE <= SSTATE_C;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -182,26 +184,28 @@ BEGIN
     -- GENERATE H SYNC PULSE
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_HSYNC_N <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( FF_SSTATE = SSTATE_A )THEN
-                IF( (HCOUNTERIN = 1) OR (HCOUNTERIN = CLOCKS_PER_LINE/2+1) ) THEN
-                    FF_HSYNC_N <= '0';                       -- PULSE ON
-                ELSIF( (HCOUNTERIN = 51) OR (HCOUNTERIN = CLOCKS_PER_LINE/2+51) ) THEN
-                    FF_HSYNC_N <= '1';                       -- PULSE OFF
-                END IF;
-            ELSIF( FF_SSTATE = SSTATE_B )THEN
-                IF( (HCOUNTERIN = CLOCKS_PER_LINE-100+1 ) OR (HCOUNTERIN = CLOCKS_PER_LINE/2-100+1) ) THEN
-                    FF_HSYNC_N <= '0';                       -- PULSE ON
-                ELSIF( (HCOUNTERIN = 1) OR (HCOUNTERIN = CLOCKS_PER_LINE/2+1) ) THEN
-                    FF_HSYNC_N <= '1';                       -- PULSE OFF
-                END IF;
-            ELSIF( FF_SSTATE = SSTATE_C )THEN
-                IF( HCOUNTERIN = 1 )THEN
-                    FF_HSYNC_N <= '0';                       -- PULSE ON
-                ELSIF( HCOUNTERIN = 101 )THEN
-                    FF_HSYNC_N <= '1';                       -- PULSE OFF
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FF_HSYNC_N <= '0';
+	    ELSE
+                IF( FF_SSTATE = SSTATE_A )THEN
+                    IF( (HCOUNTERIN = 1) OR (HCOUNTERIN = CLOCKS_PER_LINE/2+1) ) THEN
+                        FF_HSYNC_N <= '0';                       -- PULSE ON
+                    ELSIF( (HCOUNTERIN = 51) OR (HCOUNTERIN = CLOCKS_PER_LINE/2+51) ) THEN
+                        FF_HSYNC_N <= '1';                       -- PULSE OFF
+                    END IF;
+                ELSIF( FF_SSTATE = SSTATE_B )THEN
+                    IF( (HCOUNTERIN = CLOCKS_PER_LINE-100+1 ) OR (HCOUNTERIN = CLOCKS_PER_LINE/2-100+1) ) THEN
+                        FF_HSYNC_N <= '0';                       -- PULSE ON
+                    ELSIF( (HCOUNTERIN = 1) OR (HCOUNTERIN = CLOCKS_PER_LINE/2+1) ) THEN
+                        FF_HSYNC_N <= '1';                       -- PULSE OFF
+                    END IF;
+                ELSIF( FF_SSTATE = SSTATE_C )THEN
+                    IF( HCOUNTERIN = 1 )THEN
+                        FF_HSYNC_N <= '0';                       -- PULSE ON
+                    ELSIF( HCOUNTERIN = 101 )THEN
+                        FF_HSYNC_N <= '1';                       -- PULSE OFF
+                    END IF;
                 END IF;
             END IF;
         END IF;

--- a/VIDEO/vdp_sprite.vhd
+++ b/VIDEO/vdp_sprite.vhd
@@ -354,11 +354,13 @@ BEGIN
     ---------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_SP_EN <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "01" AND DOTCOUNTERX = 0 )THEN
-                FF_SP_EN <= (NOT REG_R8_SP_OFF) AND W_ACTIVE;
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_SP_EN <= '0';
+	    ELSE
+                IF( DOTSTATE = "01" AND DOTCOUNTERX = 0 )THEN
+                    FF_SP_EN <= (NOT REG_R8_SP_OFF) AND W_ACTIVE;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -434,26 +436,28 @@ BEGIN
     -----------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            SPSTATE <= SPSTATE_IDLE;
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "10" )THEN
-                CASE SPSTATE IS
-                WHEN SPSTATE_IDLE =>
-                    IF( DOTCOUNTERX = 0 )THEN
-                        SPSTATE <= SPSTATE_YTEST_DRAW;
-                    END IF;
-                WHEN SPSTATE_YTEST_DRAW =>
-                    IF( DOTCOUNTERX = 256+8 )THEN
-                        SPSTATE <= SPSTATE_PREPARE;
-                    END IF;
-                WHEN SPSTATE_PREPARE =>
-                    IF( SPPREPAREEND = '1' )THEN
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                SPSTATE <= SPSTATE_IDLE;
+	    ELSE
+                IF( DOTSTATE = "10" )THEN
+                    CASE SPSTATE IS
+                    WHEN SPSTATE_IDLE =>
+                        IF( DOTCOUNTERX = 0 )THEN
+                            SPSTATE <= SPSTATE_YTEST_DRAW;
+                        END IF;
+                    WHEN SPSTATE_YTEST_DRAW =>
+                        IF( DOTCOUNTERX = 256+8 )THEN
+                            SPSTATE <= SPSTATE_PREPARE;
+                        END IF;
+                    WHEN SPSTATE_PREPARE =>
+                        IF( SPPREPAREEND = '1' )THEN
+                            SPSTATE <= SPSTATE_IDLE;
+                        END IF;
+                    WHEN OTHERS =>
                         SPSTATE <= SPSTATE_IDLE;
-                    END IF;
-                WHEN OTHERS =>
-                    SPSTATE <= SPSTATE_IDLE;
-                END CASE;
+                    END CASE;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -494,26 +498,28 @@ BEGIN
     -----------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            SPVRAMACCESSING <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "10" )THEN
-                CASE SPSTATE IS
-                WHEN SPSTATE_IDLE =>
-                    IF( DOTCOUNTERX = 0 )THEN
-                        SPVRAMACCESSING <= (NOT REG_R8_SP_OFF) AND W_ACTIVE;
-                    END IF;
-                WHEN SPSTATE_YTEST_DRAW =>
-                    IF( DOTCOUNTERX = 256+8 )THEN
-                        SPVRAMACCESSING <= FF_SP_EN;
-                    END IF;
-                WHEN SPSTATE_PREPARE =>
-                    IF( SPPREPAREEND = '1' )THEN
-                        SPVRAMACCESSING <= '0';
-                    END IF;
-                WHEN OTHERS =>
-                    NULL;
-                END CASE;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                SPVRAMACCESSING <= '0';
+	    ELSE
+                IF( DOTSTATE = "10" )THEN
+                    CASE SPSTATE IS
+                    WHEN SPSTATE_IDLE =>
+                        IF( DOTCOUNTERX = 0 )THEN
+                            SPVRAMACCESSING <= (NOT REG_R8_SP_OFF) AND W_ACTIVE;
+                        END IF;
+                    WHEN SPSTATE_YTEST_DRAW =>
+                        IF( DOTCOUNTERX = 256+8 )THEN
+                            SPVRAMACCESSING <= FF_SP_EN;
+                        END IF;
+                    WHEN SPSTATE_PREPARE =>
+                        IF( SPPREPAREEND = '1' )THEN
+                            SPVRAMACCESSING <= '0';
+                        END IF;
+                    WHEN OTHERS =>
+                        NULL;
+                    END CASE;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -546,15 +552,17 @@ BEGIN
     ---------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_Y_TEST_EN <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "01" )THEN
-                IF( DOTCOUNTERX = 0 ) THEN
-                    FF_Y_TEST_EN <= FF_SP_EN;
-                ELSIF( EIGHTDOTSTATE = "110" )THEN
-                    IF( W_SP_OFF = '1' OR (W_SP_OVERMAP AND W_TARGET_SP_EN) = '1' OR FF_Y_TEST_SP_NUM = "11111" )THEN
-                        FF_Y_TEST_EN <= '0';
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FF_Y_TEST_EN <= '0';
+	    ELSE
+                IF( DOTSTATE = "01" )THEN
+                    IF( DOTCOUNTERX = 0 ) THEN
+                        FF_Y_TEST_EN <= FF_SP_EN;
+                    ELSIF( EIGHTDOTSTATE = "110" )THEN
+                        IF( W_SP_OFF = '1' OR (W_SP_OVERMAP AND W_TARGET_SP_EN) = '1' OR FF_Y_TEST_SP_NUM = "11111" )THEN
+                            FF_Y_TEST_EN <= '0';
+                        END IF;
                     END IF;
                 END IF;
             END IF;
@@ -566,15 +574,17 @@ BEGIN
     ---------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_Y_TEST_SP_NUM <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "01" )THEN
-                IF( DOTCOUNTERX = 0 )THEN
-                    FF_Y_TEST_SP_NUM <= (OTHERS => '0');
-                ELSIF( EIGHTDOTSTATE = "110" )THEN
-                    IF( FF_Y_TEST_EN = '1' AND FF_Y_TEST_SP_NUM /= "11111" )THEN
-                        FF_Y_TEST_SP_NUM <= FF_Y_TEST_SP_NUM + 1;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FF_Y_TEST_SP_NUM <= (OTHERS => '0');
+	    ELSE
+                IF( DOTSTATE = "01" )THEN
+                    IF( DOTCOUNTERX = 0 )THEN
+                        FF_Y_TEST_SP_NUM <= (OTHERS => '0');
+                    ELSIF( EIGHTDOTSTATE = "110" )THEN
+                        IF( FF_Y_TEST_EN = '1' AND FF_Y_TEST_SP_NUM /= "11111" )THEN
+                            FF_Y_TEST_SP_NUM <= FF_Y_TEST_SP_NUM + 1;
+                        END IF;
                     END IF;
                 END IF;
             END IF;
@@ -586,17 +596,19 @@ BEGIN
     ---------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_Y_TEST_LISTUP_ADDR <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "01" )THEN
-                IF( DOTCOUNTERX = 0 )THEN
-                    -- INITIALIZE
-                    FF_Y_TEST_LISTUP_ADDR <= (OTHERS => '0');
-                ELSIF( EIGHTDOTSTATE = "110" )THEN
-                    -- NEXT SPRITE [リストアップメモリが満杯になるまでインクリメント]
-                    IF( FF_Y_TEST_EN = '1' AND W_TARGET_SP_EN = '1' AND W_SP_OVERMAP = '0' AND W_SP_OFF = '0' )THEN
-                        FF_Y_TEST_LISTUP_ADDR <= FF_Y_TEST_LISTUP_ADDR + 1;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FF_Y_TEST_LISTUP_ADDR <= (OTHERS => '0');
+	    ELSE
+                IF( DOTSTATE = "01" )THEN
+                    IF( DOTCOUNTERX = 0 )THEN
+                        -- INITIALIZE
+                        FF_Y_TEST_LISTUP_ADDR <= (OTHERS => '0');
+                    ELSIF( EIGHTDOTSTATE = "110" )THEN
+                        -- NEXT SPRITE [リストアップメモリが満杯になるまでインクリメント]
+                        IF( FF_Y_TEST_EN = '1' AND W_TARGET_SP_EN = '1' AND W_SP_OVERMAP = '0' AND W_SP_OFF = '0' )THEN
+                            FF_Y_TEST_LISTUP_ADDR <= FF_Y_TEST_LISTUP_ADDR + 1;
+                        END IF;
                     END IF;
                 END IF;
             END IF;
@@ -627,21 +639,23 @@ BEGIN
     ---------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_SP_OVERMAP       <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( PVDPS0RESETREQ = NOT FF_VDPS0RESETACK )THEN
-                -- S#0が読み込まれるまでクリアしない
-                FF_SP_OVERMAP       <= '0';
-            ELSIF( DOTSTATE = "01" )THEN
-                IF( DOTCOUNTERX = 0 )THEN
-                    -- INITIALIZE
-                ELSIF( EIGHTDOTSTATE = "110" )THEN
-                    IF( FF_Y_TEST_EN = '1' AND W_TARGET_SP_EN = '1' AND W_SP_OVERMAP = '1' AND W_SP_OFF = '0' )THEN
-                        FF_SP_OVERMAP <= '1';
-                    END IF;
-                END IF;
-            END IF;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+           IF( RESET = '1' )THEN
+               FF_SP_OVERMAP       <= '0';
+	   ELSE
+               IF( PVDPS0RESETREQ = NOT FF_VDPS0RESETACK )THEN
+                   -- S#0が読み込まれるまでクリアしない
+                   FF_SP_OVERMAP       <= '0';
+               ELSIF( DOTSTATE = "01" )THEN
+                   IF( DOTCOUNTERX = 0 )THEN
+                       -- INITIALIZE
+                   ELSIF( EIGHTDOTSTATE = "110" )THEN
+                       IF( FF_Y_TEST_EN = '1' AND W_TARGET_SP_EN = '1' AND W_SP_OVERMAP = '1' AND W_SP_OFF = '0' )THEN
+                           FF_SP_OVERMAP <= '1';
+                       END IF;
+                   END IF;
+               END IF;
+           END IF;
         END IF;
     END PROCESS;
 
@@ -650,19 +664,21 @@ BEGIN
     ---------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_SP_OVERMAP_NUM   <= (OTHERS => '1');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( PVDPS0RESETREQ = NOT FF_VDPS0RESETACK )THEN
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
                 FF_SP_OVERMAP_NUM   <= (OTHERS => '1');
-            ELSIF( DOTSTATE = "01" )THEN
-                IF( DOTCOUNTERX = 0 )THEN
-                    -- INITIALIZE
-                ELSIF( EIGHTDOTSTATE = "110" )THEN
-                    -- JP: 調査をあきらめたスプライト番号が格納される。OVERMAPとは限らない。
-                    -- JP: しかし、すでに OVERMAP で値が確定している場合は更新しない。
-                    IF( FF_Y_TEST_EN = '1' AND W_TARGET_SP_EN = '1' AND W_SP_OVERMAP = '1' AND W_SP_OFF = '0' AND FF_SP_OVERMAP = '0' )THEN
-                        FF_SP_OVERMAP_NUM <= FF_Y_TEST_SP_NUM;
+	    ELSE
+                IF( PVDPS0RESETREQ = NOT FF_VDPS0RESETACK )THEN
+                    FF_SP_OVERMAP_NUM   <= (OTHERS => '1');
+                ELSIF( DOTSTATE = "01" )THEN
+                    IF( DOTCOUNTERX = 0 )THEN
+                        -- INITIALIZE
+                    ELSIF( EIGHTDOTSTATE = "110" )THEN
+                        -- JP: 調査をあきらめたスプライト番号が格納される。OVERMAPとは限らない。
+                        -- JP: しかし、すでに OVERMAP で値が確定している場合は更新しない。
+                        IF( FF_Y_TEST_EN = '1' AND W_TARGET_SP_EN = '1' AND W_SP_OVERMAP = '1' AND W_SP_OFF = '0' AND FF_SP_OVERMAP = '0' )THEN
+                            FF_SP_OVERMAP_NUM <= FF_Y_TEST_SP_NUM;
+                        END IF;
                     END IF;
                 END IF;
             END IF;
@@ -674,11 +690,13 @@ BEGIN
     ---------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_Y_TEST_VRAM_ADDR <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "11" )THEN
-                FF_Y_TEST_VRAM_ADDR <= SPATTRTBLBASEADDR & FF_Y_TEST_SP_NUM & "00";
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                FF_Y_TEST_VRAM_ADDR <= (OTHERS => '0');
+	    ELSE
+                IF( DOTSTATE = "11" )THEN
+                    FF_Y_TEST_VRAM_ADDR <= SPATTRTBLBASEADDR & FF_Y_TEST_SP_NUM & "00";
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -703,25 +721,27 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            IRAMADRPREPARE <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            -- PREPAREING
-            IF( DOTSTATE = "11" )THEN
-                CASE EIGHTDOTSTATE IS
-                WHEN "000" =>                               -- Y READ
-                    IRAMADRPREPARE <= SPATTRIB_ADDR & "00";
-                WHEN "001" =>                               -- X READ
-                    IRAMADRPREPARE <= SPATTRIB_ADDR & "01";
-                WHEN "010" =>                               -- PATTERN NUM READ
-                    IRAMADRPREPARE <= SPATTRIB_ADDR & "10";
-                WHEN "011" | "100" =>                       -- PATTERN READ
-                    IRAMADRPREPARE <= READVRAMADDRPTREAD;
-                WHEN "101" =>                               -- COLOR READ
-                    IRAMADRPREPARE <= READVRAMADDRCREAD;
-                WHEN OTHERS =>
-                    NULL;
-                END CASE;
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                IRAMADRPREPARE <= (OTHERS => '0');
+	    ELSE
+                -- PREPAREING
+                IF( DOTSTATE = "11" )THEN
+                    CASE EIGHTDOTSTATE IS
+                    WHEN "000" =>                               -- Y READ
+                        IRAMADRPREPARE <= SPATTRIB_ADDR & "00";
+                    WHEN "001" =>                               -- X READ
+                        IRAMADRPREPARE <= SPATTRIB_ADDR & "01";
+                    WHEN "010" =>                               -- PATTERN NUM READ
+                        IRAMADRPREPARE <= SPATTRIB_ADDR & "10";
+                    WHEN "011" | "100" =>                       -- PATTERN READ
+                        IRAMADRPREPARE <= READVRAMADDRPTREAD;
+                    WHEN "101" =>                               -- COLOR READ
+                        IRAMADRPREPARE <= READVRAMADDRCREAD;
+                    WHEN OTHERS =>
+                        NULL;
+                    END CASE;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -748,77 +768,79 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            SPPREPARELOCALPLANENUM  <= (OTHERS => '0');
-            SPPREPAREEND            <= '0';
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
+                SPPREPARELOCALPLANENUM  <= (OTHERS => '0');
+                SPPREPAREEND            <= '0';
 
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            -- PREPAREING
-            CASE DOTSTATE IS
-                WHEN "01" =>
-                    IF( SPSTATE = SPSTATE_PREPARE ) THEN
-                        CASE EIGHTDOTSTATE IS
-                            WHEN "001" =>                               -- Y READ
-                                -- JP: スプライトの何行目が該当したか覚えておく
-                                IF( REG_R1_SP_ZOOM = '0' ) THEN
-                                    SPPREPARELINENUM    <= W_SPLISTUPY(3 DOWNTO 0);
-                                ELSE
-                                    SPPREPARELINENUM    <= W_SPLISTUPY(4 DOWNTO 1);
-                                END IF;
-                            WHEN "010" =>                               -- X READ
-                                SPINFORAMX_IN <= '0' & PRAMDAT;
-                            WHEN "011" =>                               -- PATTERN NUM READ
-                                SPPREPAREPATTERNNUM <= PRAMDAT;
-                            WHEN "100" =>                               -- PATTERN READ LEFT
-                                SPINFORAMPATTERN_IN(15 DOWNTO 8) <= PRAMDAT;
-                            WHEN "101" =>                               -- PATTERN READ RIGHT
-                                IF( REG_R1_SP_SIZE = '0' ) THEN
-                                    -- 8X8 MODE
-                                    SPINFORAMPATTERN_IN( 7 DOWNTO 0) <= (OTHERS => '0');
-                                ELSE
-                                    -- 16X16 MODE
-                                    SPINFORAMPATTERN_IN( 7 DOWNTO 0) <= PRAMDAT;
-                                END IF;
-                            WHEN "110" =>                               -- COLOR READ
-                                -- COLOR
-                                SPINFORAMCOLOR_IN <= PRAMDAT(3 DOWNTO 0);
-                                -- CC   優先順位ビット (1: 優先順位無し, 0: 優先順位あり)
-                                IF(SPMODE2 = '1') THEN
-                                    SPINFORAMCC_IN <= PRAMDAT(6);
-                                ELSE
-                                    SPINFORAMCC_IN <= '0';
-                                END IF;
-                                -- IC   衝突検知ビット (1: 検知しない, 0: 検知する)
-                                SPINFORAMIC_IN <= PRAMDAT(5) AND SPMODE2;
-                                -- EC   32ドット左シフト (1: する, 0: しない)
-                                IF( PRAMDAT(7) = '1' ) THEN
-                                    SPINFORAMX_IN <= SPINFORAMX_IN - 32;
-                                END IF;
+	    ELSE
+                -- PREPARING
+                CASE DOTSTATE IS
+                    WHEN "01" =>
+                        IF( SPSTATE = SPSTATE_PREPARE ) THEN
+                            CASE EIGHTDOTSTATE IS
+                                WHEN "001" =>                               -- Y READ
+                                    -- JP: スプライトの何行目が該当したか覚えておく
+                                    IF( REG_R1_SP_ZOOM = '0' ) THEN
+                                        SPPREPARELINENUM    <= W_SPLISTUPY(3 DOWNTO 0);
+                                    ELSE
+                                        SPPREPARELINENUM    <= W_SPLISTUPY(4 DOWNTO 1);
+                                    END IF;
+                                WHEN "010" =>                               -- X READ
+                                    SPINFORAMX_IN <= '0' & PRAMDAT;
+                                WHEN "011" =>                               -- PATTERN NUM READ
+                                    SPPREPAREPATTERNNUM <= PRAMDAT;
+                                WHEN "100" =>                               -- PATTERN READ LEFT
+                                    SPINFORAMPATTERN_IN(15 DOWNTO 8) <= PRAMDAT;
+                                WHEN "101" =>                               -- PATTERN READ RIGHT
+                                    IF( REG_R1_SP_SIZE = '0' ) THEN
+                                        -- 8X8 MODE
+                                        SPINFORAMPATTERN_IN( 7 DOWNTO 0) <= (OTHERS => '0');
+                                    ELSE
+                                        -- 16X16 MODE
+                                        SPINFORAMPATTERN_IN( 7 DOWNTO 0) <= PRAMDAT;
+                                    END IF;
+                                WHEN "110" =>                               -- COLOR READ
+                                    -- COLOR
+                                    SPINFORAMCOLOR_IN <= PRAMDAT(3 DOWNTO 0);
+                                    -- CC   優先順位ビット (1: 優先順位無し, 0: 優先順位あり)
+                                    IF(SPMODE2 = '1') THEN
+                                        SPINFORAMCC_IN <= PRAMDAT(6);
+                                    ELSE
+                                        SPINFORAMCC_IN <= '0';
+                                    END IF;
+                                    -- IC   衝突検知ビット (1: 検知しない, 0: 検知する)
+                                    SPINFORAMIC_IN <= PRAMDAT(5) AND SPMODE2;
+                                    -- EC   32ドット左シフト (1: する, 0: しない)
+                                    IF( PRAMDAT(7) = '1' ) THEN
+                                        SPINFORAMX_IN <= SPINFORAMX_IN - 32;
+                                    END IF;
 
-                                -- IF ALL OF THE SPRITES LIST-UPED ARE READED,
-                                -- THE SPRITES LEFT SHOULD NOT BE DRAWN.
-                                IF( SPPREPARELOCALPLANENUM >= FF_Y_TEST_LISTUP_ADDR )THEN
-                                    SPINFORAMPATTERN_IN <= (OTHERS => '0');
-                                END IF;
-                            WHEN "111" =>
-                                SPPREPARELOCALPLANENUM <= SPPREPARELOCALPLANENUM + 1;
-                                IF( SPPREPARELOCALPLANENUM = 7 ) THEN
-                                    SPPREPAREEND <= '1';
-                                END IF;
-                            WHEN OTHERS =>
-                                NULL;
-                        END CASE;
-                    ELSE
-                        SPPREPARELOCALPLANENUM <= (OTHERS => '0');
-                        SPPREPAREEND <= '0';
-                    END IF;
-                WHEN OTHERS =>
-                    NULL;
-            END CASE;
+                                    -- IF ALL OF THE SPRITES LIST-UPED ARE READED,
+                                    -- THE SPRITES LEFT SHOULD NOT BE DRAWN.
+                                    IF( SPPREPARELOCALPLANENUM >= FF_Y_TEST_LISTUP_ADDR )THEN
+                                        SPINFORAMPATTERN_IN <= (OTHERS => '0');
+                                    END IF;
+                                WHEN "111" =>
+                                    SPPREPARELOCALPLANENUM <= SPPREPARELOCALPLANENUM + 1;
+                                    IF( SPPREPARELOCALPLANENUM = 7 ) THEN
+                                        SPPREPAREEND <= '1';
+                                    END IF;
+                                WHEN OTHERS =>
+                                    NULL;
+                            END CASE;
+                        ELSE
+                            SPPREPARELOCALPLANENUM <= (OTHERS => '0');
+                            SPPREPAREEND <= '0';
+                        END IF;
+                    WHEN OTHERS =>
+                        NULL;
+                END CASE;
+            END IF;
         END IF;
     END PROCESS;
 
-    PROCESS( RESET, CLK21M )
+    PROCESS( CLK21M )
     BEGIN
         IF( CLK21M'EVENT AND CLK21M = '1' )THEN
             IF( DOTSTATE = "01" )THEN
@@ -850,106 +872,109 @@ BEGIN
         VARIABLE VDPS3S4SPCOLLISIONXV               : STD_LOGIC_VECTOR(8 DOWNTO 0);
         VARIABLE VDPS5S6SPCOLLISIONYV               : STD_LOGIC_VECTOR(8 DOWNTO 0);
     BEGIN
-        IF( RESET ='1' ) THEN
-            SPLINEBUFDRAWWE             <= '0';                 -- JP: ラインバッファへの書き込みイネーブラ
-            SPPREDRAWEND                <= '0';
-            SPDRAWPATTERN               <= (OTHERS => '0');
-            SPLINEBUFDRAWCOLOR          <= (OTHERS => '0');
-            SPLINEBUFDRAWX              <= (OTHERS => '0');
-            SPDRAWCOLOR                 <= (OTHERS => '0');
+        IF (CLK21M'EVENT AND CLK21M = '1') THEN
+            IF( RESET ='1' ) THEN
+                SPLINEBUFDRAWWE             <= '0';                 -- JP: ラインバッファへの書き込みイネーブラ
+                SPPREDRAWEND                <= '0';
+                SPDRAWPATTERN               <= (OTHERS => '0');
+                SPLINEBUFDRAWCOLOR          <= (OTHERS => '0');
+                SPLINEBUFDRAWX              <= (OTHERS => '0');
+                SPDRAWCOLOR                 <= (OTHERS => '0');
 
-            VDPS0SPCOLLISIONINCIDENCEV  := '0';                 -- JP: スプライトが衝突したかどうかを示すフラグ
-            VDPS3S4SPCOLLISIONXV        := (OTHERS => '0');
-            VDPS5S6SPCOLLISIONYV        := (OTHERS => '0');
-            SPCC0FOUNDV                 := '0';
-            LASTCC0LOCALPLANENUMV       := (OTHERS => '0');
+                VDPS0SPCOLLISIONINCIDENCEV  := '0';                 -- JP: スプライトが衝突したかどうかを示すフラグ
+                VDPS3S4SPCOLLISIONXV        := (OTHERS => '0');
+                VDPS5S6SPCOLLISIONYV        := (OTHERS => '0');
+                SPCC0FOUNDV                 := '0';
+                LASTCC0LOCALPLANENUMV       := (OTHERS => '0');
 
-        ELSIF (CLK21M'EVENT AND CLK21M = '1') THEN
-            IF( SPSTATE = SPSTATE_YTEST_DRAW ) THEN
-                CASE DOTSTATE IS
-                    WHEN "10" =>
-                        -- JP: 処理単位の始まり
-                        SPLINEBUFDRAWWE <= '0';
-                    WHEN "00" =>
-                        -- JP:
-                        IF( DOTCOUNTERX(4 DOWNTO 0) = 1 ) THEN
-                            SPDRAWPATTERN   <= SPINFORAMPATTERN_OUT;
-                            SPDRAWXV        := SPINFORAMX_OUT;
-                        ELSE
-                            IF( (REG_R1_SP_ZOOM = '0') OR (DOTCOUNTERX(0) = '1') ) THEN
-                                SPDRAWPATTERN <= SPDRAWPATTERN(14 DOWNTO 0) & "0";
+	    ELSE
+
+                IF( SPSTATE = SPSTATE_YTEST_DRAW ) THEN
+                    CASE DOTSTATE IS
+                        WHEN "10" =>
+                            -- JP: 処理単位の始まり
+                            SPLINEBUFDRAWWE <= '0';
+                        WHEN "00" =>
+                            -- JP:
+                            IF( DOTCOUNTERX(4 DOWNTO 0) = 1 ) THEN
+                                SPDRAWPATTERN   <= SPINFORAMPATTERN_OUT;
+                                SPDRAWXV        := SPINFORAMX_OUT;
+                            ELSE
+                                IF( (REG_R1_SP_ZOOM = '0') OR (DOTCOUNTERX(0) = '1') ) THEN
+                                    SPDRAWPATTERN <= SPDRAWPATTERN(14 DOWNTO 0) & "0";
+                                END IF;
+                                SPDRAWXV := SPDRAWX + 1;
                             END IF;
-                            SPDRAWXV := SPDRAWX + 1;
-                        END IF;
-                        SPDRAWX <= SPDRAWXV;
-                        SPLINEBUFDRAWX <= SPDRAWXV(7 DOWNTO 0);
-                    WHEN "01" =>
-                        SPDRAWCOLOR <= SPINFORAMCOLOR_OUT;
-                    WHEN "11" =>
-                        IF( SPINFORAMCC_OUT = '0' ) THEN
-                            LASTCC0LOCALPLANENUMV := SPPREDRAWLOCALPLANENUM;
-                            SPCC0FOUNDV := '1';
-                        END IF;
-                        IF( (SPDRAWPATTERN(15) = '1') AND (SPDRAWX(8) = '0') AND (SPPREDRAWEND = '0') AND
-                                ((REG_R8_COL0_ON = '1') OR (SPDRAWCOLOR /= 0)) ) THEN
-                            -- JP: スプライトのドットを描画
-                            -- JP: ラインバッファの7ビット目は、何らかの色を描画した時に'1'になる。
-                            -- JP: ラインバッファの6-4ビット目はそこに描画されているドットのローカルプレーン番号
-                            -- JP: (色合成されているときは親となるCC='0'のスプライトのローカルプレーン番号)が入る。
-                            -- JP: つまり、LASTCC0LOCALPLANENUMVがこの番号と等しいときはOR合成してよい事になる。
-                            IF( (SPLINEBUFDRAWDATA_OUT(7) = '0') AND (SPCC0FOUNDV = '1') ) THEN
-                                -- JP: 何も描かれていない(ビット7が'0')とき、このドットに初めての
-                                -- JP: スプライトが描画される。ただし、CC='0'のスプライトが同一ライン上にまだ
-                                -- JP: 現れていない時は描画しない
-                                SPLINEBUFDRAWCOLOR <= ("1" & LASTCC0LOCALPLANENUMV & SPDRAWCOLOR);
-                                SPLINEBUFDRAWWE <= '1';
-                            ELSIF( (SPLINEBUFDRAWDATA_OUT(7) = '1') AND (SPINFORAMCC_OUT = '1') AND
-                                         (SPLINEBUFDRAWDATA_OUT(6 DOWNTO 4) = LASTCC0LOCALPLANENUMV) ) THEN
-                                -- JP: 既に絵が描かれているが、CCが'1'でかつこのドットに描かれているスプライトの
-                                -- JP: LOCALPLANENUMが LASTCC0LOCALPLANENUMVと等しい時は、ラインバッファから
-                                -- JP: 下地データを読み、書きたい色と論理和を取リ、書き戻す。
-                                SPLINEBUFDRAWCOLOR <= SPLINEBUFDRAWDATA_OUT OR ("0000" & SPDRAWCOLOR);
-                                SPLINEBUFDRAWWE <= '1';
-                            ELSIF( (SPLINEBUFDRAWDATA_OUT(7) = '1') AND (SPINFORAMIC_OUT = '0') ) THEN
-                                SPLINEBUFDRAWCOLOR <= SPLINEBUFDRAWDATA_OUT;
-                                -- JP: スプライトが衝突。
-                                -- SPRITE COLISION OCCURED
-                                VDPS0SPCOLLISIONINCIDENCEV := '1';
-                                VDPS3S4SPCOLLISIONXV := SPDRAWX + 12;
-                                -- NOTE: DRAWING LINE IS PREVIOUS LINE.
-                                VDPS5S6SPCOLLISIONYV := FF_CUR_Y + 7;
+                            SPDRAWX <= SPDRAWXV;
+                            SPLINEBUFDRAWX <= SPDRAWXV(7 DOWNTO 0);
+                        WHEN "01" =>
+                            SPDRAWCOLOR <= SPINFORAMCOLOR_OUT;
+                        WHEN "11" =>
+                            IF( SPINFORAMCC_OUT = '0' ) THEN
+                                LASTCC0LOCALPLANENUMV := SPPREDRAWLOCALPLANENUM;
+                                SPCC0FOUNDV := '1';
                             END IF;
-                        END IF;
-                        --
-                        IF( DOTCOUNTERX = 0 ) THEN
-                            SPPREDRAWLOCALPLANENUM <= (OTHERS => '0');
-                            SPPREDRAWEND <= '0';
-                            LASTCC0LOCALPLANENUMV := (OTHERS => '0');
-                            SPCC0FOUNDV := '0';
-                        ELSIF( DOTCOUNTERX(4 DOWNTO 0) = 0 ) THEN
-                            SPPREDRAWLOCALPLANENUM <= SPPREDRAWLOCALPLANENUM + 1;
-                            IF( SPPREDRAWLOCALPLANENUM = 7 ) THEN
-                                SPPREDRAWEND <= '1';
+                            IF( (SPDRAWPATTERN(15) = '1') AND (SPDRAWX(8) = '0') AND (SPPREDRAWEND = '0') AND
+                                    ((REG_R8_COL0_ON = '1') OR (SPDRAWCOLOR /= 0)) ) THEN
+                                -- JP: スプライトのドットを描画
+                                -- JP: ラインバッファの7ビット目は、何らかの色を描画した時に'1'になる。
+                                -- JP: ラインバッファの6-4ビット目はそこに描画されているドットのローカルプレーン番号
+                                -- JP: (色合成されているときは親となるCC='0'のスプライトのローカルプレーン番号)が入る。
+                                -- JP: つまり、LASTCC0LOCALPLANENUMVがこの番号と等しいときはOR合成してよい事になる。
+                                IF( (SPLINEBUFDRAWDATA_OUT(7) = '0') AND (SPCC0FOUNDV = '1') ) THEN
+                                    -- JP: 何も描かれていない(ビット7が'0')とき、このドットに初めての
+                                    -- JP: スプライトが描画される。ただし、CC='0'のスプライトが同一ライン上にまだ
+                                    -- JP: 現れていない時は描画しない
+                                    SPLINEBUFDRAWCOLOR <= ("1" & LASTCC0LOCALPLANENUMV & SPDRAWCOLOR);
+                                    SPLINEBUFDRAWWE <= '1';
+                                ELSIF( (SPLINEBUFDRAWDATA_OUT(7) = '1') AND (SPINFORAMCC_OUT = '1') AND
+                                             (SPLINEBUFDRAWDATA_OUT(6 DOWNTO 4) = LASTCC0LOCALPLANENUMV) ) THEN
+                                    -- JP: 既に絵が描かれているが、CCが'1'でかつこのドットに描かれているスプライトの
+                                    -- JP: LOCALPLANENUMが LASTCC0LOCALPLANENUMVと等しい時は、ラインバッファから
+                                    -- JP: 下地データを読み、書きたい色と論理和を取リ、書き戻す。
+                                    SPLINEBUFDRAWCOLOR <= SPLINEBUFDRAWDATA_OUT OR ("0000" & SPDRAWCOLOR);
+                                    SPLINEBUFDRAWWE <= '1';
+                                ELSIF( (SPLINEBUFDRAWDATA_OUT(7) = '1') AND (SPINFORAMIC_OUT = '0') ) THEN
+                                    SPLINEBUFDRAWCOLOR <= SPLINEBUFDRAWDATA_OUT;
+                                    -- JP: スプライトが衝突。
+                                    -- SPRITE COLISION OCCURED
+                                    VDPS0SPCOLLISIONINCIDENCEV := '1';
+                                    VDPS3S4SPCOLLISIONXV := SPDRAWX + 12;
+                                    -- NOTE: DRAWING LINE IS PREVIOUS LINE.
+                                    VDPS5S6SPCOLLISIONYV := FF_CUR_Y + 7;
+                                END IF;
                             END IF;
-                        END IF;
-                    WHEN OTHERS => NULL;
-                END CASE;
-            END IF;
+                            --
+                            IF( DOTCOUNTERX = 0 ) THEN
+                                SPPREDRAWLOCALPLANENUM <= (OTHERS => '0');
+                                SPPREDRAWEND <= '0';
+                                LASTCC0LOCALPLANENUMV := (OTHERS => '0');
+                                SPCC0FOUNDV := '0';
+                            ELSIF( DOTCOUNTERX(4 DOWNTO 0) = 0 ) THEN
+                                SPPREDRAWLOCALPLANENUM <= SPPREDRAWLOCALPLANENUM + 1;
+                                IF( SPPREDRAWLOCALPLANENUM = 7 ) THEN
+                                    SPPREDRAWEND <= '1';
+                                END IF;
+                            END IF;
+                        WHEN OTHERS => NULL;
+                    END CASE;
+                END IF;
 
-            -- STATUS REGISTER
-            IF( PVDPS0RESETREQ /= FF_VDPS0RESETACK ) THEN
-                FF_VDPS0RESETACK <= PVDPS0RESETREQ;
-                VDPS0SPCOLLISIONINCIDENCEV := '0';
-            END IF;
-            IF( PVDPS5RESETREQ /= FF_VDPS5RESETACK ) THEN
-                FF_VDPS5RESETACK <= PVDPS5RESETREQ;
-                VDPS3S4SPCOLLISIONXV := (OTHERS => '0');
-                VDPS5S6SPCOLLISIONYV := (OTHERS => '0');
-            END IF;
+                -- STATUS REGISTER
+                IF( PVDPS0RESETREQ /= FF_VDPS0RESETACK ) THEN
+                    FF_VDPS0RESETACK <= PVDPS0RESETREQ;
+                    VDPS0SPCOLLISIONINCIDENCEV := '0';
+                END IF;
+                IF( PVDPS5RESETREQ /= FF_VDPS5RESETACK ) THEN
+                    FF_VDPS5RESETACK <= PVDPS5RESETREQ;
+                    VDPS3S4SPCOLLISIONXV := (OTHERS => '0');
+                    VDPS5S6SPCOLLISIONYV := (OTHERS => '0');
+                END IF;
 
-            PVDPS0SPCOLLISIONINCIDENCE <= VDPS0SPCOLLISIONINCIDENCEV;
-            PVDPS3S4SPCOLLISIONX    <= VDPS3S4SPCOLLISIONXV;
-            PVDPS5S6SPCOLLISIONY    <= VDPS5S6SPCOLLISIONYV;
+                PVDPS0SPCOLLISIONINCIDENCE <= VDPS0SPCOLLISIONINCIDENCEV;
+                PVDPS3S4SPCOLLISIONX    <= VDPS3S4SPCOLLISIONXV;
+                PVDPS5S6SPCOLLISIONY    <= VDPS5S6SPCOLLISIONYV;
+            END IF;
         END IF;
     END PROCESS;
 
@@ -959,15 +984,17 @@ BEGIN
     -----------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            SPLINEBUFDISPX  <= (OTHERS => '0');
-        ELSIF (CLK21M'EVENT AND CLK21M = '1') THEN
-            IF( DOTSTATE = "10" )THEN
-                -- JP: DOTCOUNTERと実際の表示(カラーコードの出力)は8ドットずれている
-                IF( DOTCOUNTERX = 8 )THEN
-                    SPLINEBUFDISPX <= ("00000" & REG_R27_H_SCROLL);
-                ELSE
-                    SPLINEBUFDISPX <= SPLINEBUFDISPX + 1;
+        IF ( RISING_EDGE(CLK21M) ) THEN
+            IF( RESET = '1' )THEN
+                SPLINEBUFDISPX  <= (OTHERS => '0');
+	    ELSE
+                IF( DOTSTATE = "10" )THEN
+                    -- JP: DOTCOUNTERと実際の表示(カラーコードの出力)は8ドットずれている
+                    IF( DOTCOUNTERX = 8 )THEN
+                        SPLINEBUFDISPX <= ("00000" & REG_R27_H_SCROLL);
+                    ELSE
+                        SPLINEBUFDISPX <= SPLINEBUFDISPX + 1;
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -975,15 +1002,17 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' ) THEN
-            SPWINDOWX <= '0';
-        ELSIF (CLK21M'EVENT AND CLK21M = '1') THEN
-            IF( DOTSTATE = "10" )THEN
-                -- JP: DOTCOUNTERと実際の表示(カラーコードの出力)は8ドットずれている
-                IF( DOTCOUNTERX = 8 )THEN
-                    SPWINDOWX <= '1';
-                ELSIF( SPLINEBUFDISPX = X"FF" ) THEN
-                    SPWINDOWX <= '0';
+        IF (CLK21M'EVENT AND CLK21M = '1') THEN
+            IF( RESET = '1' ) THEN
+                SPWINDOWX <= '0';
+	    ELSE
+                IF( DOTSTATE = "10" )THEN
+                    -- JP: DOTCOUNTERと実際の表示(カラーコードの出力)は8ドットずれている
+                    IF( DOTCOUNTERX = 8 )THEN
+                        SPWINDOWX <= '1';
+                    ELSIF( SPLINEBUFDISPX = X"FF" ) THEN
+                        SPWINDOWX <= '0';
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -991,14 +1020,16 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' ) THEN
-            SPLINEBUFDISPWE <= '0';
-        ELSIF (CLK21M'EVENT AND CLK21M = '1') THEN
-            IF( DOTSTATE = "10" )THEN
+        IF (CLK21M'EVENT AND CLK21M = '1') THEN
+            IF( RESET = '1' ) THEN
                 SPLINEBUFDISPWE <= '0';
-            ELSIF( DOTSTATE = "11" AND SPWINDOWX = '1' )THEN
-                -- CLEAR DISPLAYED DOT
-                SPLINEBUFDISPWE <= '1';
+	    ELSE
+                IF( DOTSTATE = "10" )THEN
+                    SPLINEBUFDISPWE <= '0';
+                ELSIF( DOTSTATE = "11" AND SPWINDOWX = '1' )THEN
+                    -- CLEAR DISPLAYED DOT
+                    SPLINEBUFDISPWE <= '1';
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -1006,17 +1037,19 @@ BEGIN
     -- JP: ウィンドウで表示をカットする
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' ) THEN
-            SPCOLOROUT  <= '0';                     -- JP:  0=透明, 1=スプライトドット
-            SPCOLORCODE <= (OTHERS => '0');         -- JP:  SPCOLOROUT=1 の時のスプライトドット色番号
-        ELSIF (CLK21M'EVENT AND CLK21M = '1') THEN
-            IF( DOTSTATE = "01" )THEN
-                IF( SPWINDOWX = '1' ) THEN
-                    SPCOLOROUT  <= SPLINEBUFDISPDATA_OUT( 7 );
-                    SPCOLORCODE <= SPLINEBUFDISPDATA_OUT( 3 DOWNTO 0 );
-                ELSE
-                    SPCOLOROUT  <= '0';
-                    SPCOLORCODE <= (OTHERS => '0');
+        IF (CLK21M'EVENT AND CLK21M = '1') THEN
+            IF( RESET = '1' ) THEN
+                SPCOLOROUT  <= '0';                     -- JP:  0=透明, 1=スプライトドット
+                SPCOLORCODE <= (OTHERS => '0');         -- JP:  SPCOLOROUT=1 の時のスプライトドット色番号
+	    ELSE
+                IF( DOTSTATE = "01" )THEN
+                    IF( SPWINDOWX = '1' ) THEN
+                        SPCOLOROUT  <= SPLINEBUFDISPDATA_OUT( 7 );
+                        SPCOLORCODE <= SPLINEBUFDISPDATA_OUT( 3 DOWNTO 0 );
+                    ELSE
+                        SPCOLOROUT  <= '0';
+                        SPCOLORCODE <= (OTHERS => '0');
+                    END IF;
                 END IF;
             END IF;
         END IF;

--- a/VIDEO/vdp_ssg.vhd
+++ b/VIDEO/vdp_ssg.vhd
@@ -199,36 +199,38 @@ BEGIN
     --------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_DOTSTATE     <= "00";
-            FF_VIDEO_DH_CLK <= '0';
-            FF_VIDEO_DL_CLK <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( W_H_CNT = CLOCKS_PER_LINE-1 )THEN
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
                 FF_DOTSTATE     <= "00";
-                FF_VIDEO_DH_CLK <= '1';
-                FF_VIDEO_DL_CLK <= '1';
-            ELSE
-                CASE FF_DOTSTATE IS
-                WHEN "00" =>
-                    FF_DOTSTATE     <= "01";
-                    FF_VIDEO_DH_CLK <= '0';
-                    FF_VIDEO_DL_CLK <= '1';
-                WHEN "01" =>
-                    FF_DOTSTATE     <= "11";
-                    FF_VIDEO_DH_CLK <= '1';
-                    FF_VIDEO_DL_CLK <= '0';
-                WHEN "11" =>
-                    FF_DOTSTATE     <= "10";
-                    FF_VIDEO_DH_CLK <= '0';
-                    FF_VIDEO_DL_CLK <= '0';
-                WHEN "10" =>
+                FF_VIDEO_DH_CLK <= '0';
+                FF_VIDEO_DL_CLK <= '0';
+	    ELSE
+                IF( W_H_CNT = CLOCKS_PER_LINE-1 )THEN
                     FF_DOTSTATE     <= "00";
                     FF_VIDEO_DH_CLK <= '1';
                     FF_VIDEO_DL_CLK <= '1';
-                WHEN OTHERS =>
-                    NULL;
-                END CASE;
+                ELSE
+                    CASE FF_DOTSTATE IS
+                    WHEN "00" =>
+                        FF_DOTSTATE     <= "01";
+                        FF_VIDEO_DH_CLK <= '0';
+                        FF_VIDEO_DL_CLK <= '1';
+                    WHEN "01" =>
+                        FF_DOTSTATE     <= "11";
+                        FF_VIDEO_DH_CLK <= '1';
+                        FF_VIDEO_DL_CLK <= '0';
+                    WHEN "11" =>
+                        FF_DOTSTATE     <= "10";
+                        FF_VIDEO_DH_CLK <= '0';
+                        FF_VIDEO_DL_CLK <= '0';
+                    WHEN "10" =>
+                        FF_DOTSTATE     <= "00";
+                        FF_VIDEO_DH_CLK <= '1';
+                        FF_VIDEO_DL_CLK <= '1';
+                    WHEN OTHERS =>
+                        NULL;
+                    END CASE;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -238,14 +240,16 @@ BEGIN
     --------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_EIGHTDOTSTATE <= "000";
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( W_H_CNT(1 DOWNTO 0) = "11" )THEN
-                IF( FF_PRE_X_CNT = 0 )THEN
-                    FF_EIGHTDOTSTATE <= "000";
-                ELSE
-                    FF_EIGHTDOTSTATE <= FF_EIGHTDOTSTATE + 1;
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_EIGHTDOTSTATE <= "000";
+	    ELSE
+                IF( W_H_CNT(1 DOWNTO 0) = "11" )THEN
+                    IF( FF_PRE_X_CNT = 0 )THEN
+                        FF_EIGHTDOTSTATE <= "000";
+                    ELSE
+                        FF_EIGHTDOTSTATE <= FF_EIGHTDOTSTATE + 1;
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -259,10 +263,12 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_PRE_X_CNT_START1 <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            FF_PRE_X_CNT_START1 <= (W_PRE_X_CNT_START0(4) & W_PRE_X_CNT_START0) - ("000" & REG_R27_H_SCROLL);   -- (-23...-1)
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_PRE_X_CNT_START1 <= (OTHERS => '0');
+	    ELSE
+                FF_PRE_X_CNT_START1 <= (W_PRE_X_CNT_START0(4) & W_PRE_X_CNT_START0) - ("000" & REG_R27_H_SCROLL);   -- (-23...-1)
+            END IF;
         END IF;
     END PROCESS;
 
@@ -271,36 +277,40 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_PRE_X_CNT <= (OTHERS =>'0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_NTSC - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00") + 4) & "10") AND REG_R25_YJK = '1' AND CENTERYJK_R25_N = '1' AND VDPR9PALMODE = '0') OR
-                (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_NTSC - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00")    ) & "10") AND (REG_R25_YJK = '0' OR CENTERYJK_R25_N = '0') AND VDPR9PALMODE = '0') OR
-                (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_PAL - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00") + 4) & "10") AND REG_R25_YJK = '1' AND CENTERYJK_R25_N = '1' AND VDPR9PALMODE = '1') OR
-                (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_PAL - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00")    ) & "10") AND (REG_R25_YJK = '0' OR CENTERYJK_R25_N = '0') AND VDPR9PALMODE = '1') )THEN
-                FF_PRE_X_CNT <= W_PRE_X_CNT_START2;
-            ELSIF( W_H_CNT(1 DOWNTO 0) = "10" )THEN
-                FF_PRE_X_CNT <= FF_PRE_X_CNT + 1;
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_PRE_X_CNT <= (OTHERS =>'0');
+	    ELSE
+                IF( (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_NTSC - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00") + 4) & "10") AND REG_R25_YJK = '1' AND CENTERYJK_R25_N = '1' AND VDPR9PALMODE = '0') OR
+                    (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_NTSC - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00")    ) & "10") AND (REG_R25_YJK = '0' OR CENTERYJK_R25_N = '0') AND VDPR9PALMODE = '0') OR
+                    (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_PAL - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00") + 4) & "10") AND REG_R25_YJK = '1' AND CENTERYJK_R25_N = '1' AND VDPR9PALMODE = '1') OR
+                    (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_PAL - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00")    ) & "10") AND (REG_R25_YJK = '0' OR CENTERYJK_R25_N = '0') AND VDPR9PALMODE = '1') )THEN
+                    FF_PRE_X_CNT <= W_PRE_X_CNT_START2;
+                ELSIF( W_H_CNT(1 DOWNTO 0) = "10" )THEN
+                    FF_PRE_X_CNT <= FF_PRE_X_CNT + 1;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_X_CNT <= (OTHERS =>'0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_NTSC - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00") + 4) & "10") AND REG_R25_YJK = '1' AND CENTERYJK_R25_N = '1' AND VDPR9PALMODE = '0') OR
-                (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_NTSC - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00")    ) & "10") AND (REG_R25_YJK = '0' OR CENTERYJK_R25_N = '0') AND VDPR9PALMODE = '0') OR
-                (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_PAL - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00") + 4) & "10") AND REG_R25_YJK = '1' AND CENTERYJK_R25_N = '1' AND VDPR9PALMODE = '1') OR
-                (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_PAL - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00")    ) & "10") AND (REG_R25_YJK = '0' OR CENTERYJK_R25_N = '0') AND VDPR9PALMODE = '1') )THEN
-                -- HOLD
-            ELSIF( W_H_CNT(1 DOWNTO 0) = "10") THEN
-                IF( FF_PRE_X_CNT = "111111111" )THEN
-                    -- JP: FF_PRE_X_CNT が -1から0にカウントアップする時にFF_X_CNTを-8にする
-                    FF_X_CNT <= "111111000";        -- -8
-                ELSE
-                    FF_X_CNT <= FF_X_CNT + 1;
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_X_CNT <= (OTHERS =>'0');
+	    ELSE
+                IF( (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_NTSC - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00") + 4) & "10") AND REG_R25_YJK = '1' AND CENTERYJK_R25_N = '1' AND VDPR9PALMODE = '0') OR
+                    (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_NTSC - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00")    ) & "10") AND (REG_R25_YJK = '0' OR CENTERYJK_R25_N = '0') AND VDPR9PALMODE = '0') OR
+                    (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_PAL - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00") + 4) & "10") AND REG_R25_YJK = '1' AND CENTERYJK_R25_N = '1' AND VDPR9PALMODE = '1') OR
+                    (W_H_CNT = ("00" & (OFFSET_X + LED_TV_X_PAL - ((REG_R25_MSK AND (NOT CENTERYJK_R25_N)) & "00")    ) & "10") AND (REG_R25_YJK = '0' OR CENTERYJK_R25_N = '0') AND VDPR9PALMODE = '1') )THEN
+                    -- HOLD
+                ELSIF( W_H_CNT(1 DOWNTO 0) = "10") THEN
+                    IF( FF_PRE_X_CNT = "111111111" )THEN
+                        -- JP: FF_PRE_X_CNT が -1から0にカウントアップする時にFF_X_CNTを-8にする
+                        FF_X_CNT <= "111111000";        -- -8
+                    ELSE
+                        FF_X_CNT <= FF_X_CNT + 1;
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -311,15 +321,17 @@ BEGIN
     -----------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            IVIDEOVS_N <= '1';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( W_V_CNT_IN_FIELD = 6 )THEN
-                -- SSTATE = SSTATE_B
-                IVIDEOVS_N <= '0';
-            ELSIF( W_V_CNT_IN_FIELD = 12 )THEN
-                -- SSTATE = SSTATE_A
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
                 IVIDEOVS_N <= '1';
+	    ELSE
+                IF( W_V_CNT_IN_FIELD = 6 )THEN
+                    -- SSTATE = SSTATE_B
+                    IVIDEOVS_N <= '0';
+                ELSIF( W_V_CNT_IN_FIELD = 12 )THEN
+                    -- SSTATE = SSTATE_A
+                    IVIDEOVS_N <= '1';
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -353,16 +365,18 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_WINDOW_X <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            -- MAIN WINDOW
-            IF( W_H_CNT( 1 DOWNTO 0) = "01" AND FF_X_CNT = W_LEFT_MASK ) THEN
-                -- WHEN DOTCOUNTER_X = 0
-                FF_WINDOW_X <= '1';
-            ELSIF( W_H_CNT( 1 DOWNTO 0) = "01" AND FF_X_CNT = FF_RIGHT_MASK ) THEN
-                -- WHEN DOTCOUNTER_X = 256
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
                 FF_WINDOW_X <= '0';
+	    ELSE
+                -- MAIN WINDOW
+                IF( W_H_CNT( 1 DOWNTO 0) = "01" AND FF_X_CNT = W_LEFT_MASK ) THEN
+                    -- WHEN DOTCOUNTER_X = 0
+                    FF_WINDOW_X <= '1';
+                ELSIF( W_H_CNT( 1 DOWNTO 0) = "01" AND FF_X_CNT = FF_RIGHT_MASK ) THEN
+                    -- WHEN DOTCOUNTER_X = 256
+                    FF_WINDOW_X <= '0';
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -380,50 +394,52 @@ BEGIN
         VARIABLE PREDOTCOUNTER_YP_V     : STD_LOGIC_VECTOR(  8 DOWNTO 0 );
         VARIABLE PREDOTCOUNTERYPSTART   : STD_LOGIC_VECTOR(  8 DOWNTO 0 );
     BEGIN
-        IF (RESET = '1') THEN
-            FF_PRE_Y_CNT        <= (OTHERS =>'0');
-            FF_MONITOR_LINE     <= (OTHERS =>'0');
-            PREWINDOW_Y         <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF (RESET = '1') THEN
+                FF_PRE_Y_CNT        <= (OTHERS =>'0');
+                FF_MONITOR_LINE     <= (OTHERS =>'0');
+                PREWINDOW_Y         <= '0';
+	    ELSE
 
-            IF( W_HSYNC = '1' )THEN
-                -- JP: PREWINDOW_Xが 1になるタイミングと同じタイミングでY座標の計算
-                IF(  W_V_BLANKING_END = '1' )THEN
-                    IF(    REG_R9_Y_DOTS = '0' AND VDPR9PALMODE = '0' )THEN
-                        PREDOTCOUNTERYPSTART := "111100110";    -- TOP BORDER LINES = -26
-                    ELSIF( REG_R9_Y_DOTS = '1' AND VDPR9PALMODE = '0' )THEN
-                        PREDOTCOUNTERYPSTART := "111110000";    -- TOP BORDER LINES = -16
-                    ELSIF( REG_R9_Y_DOTS = '0' AND VDPR9PALMODE = '1' )THEN
-                        PREDOTCOUNTERYPSTART := "111001011";    -- TOP BORDER LINES = -53
-                    ELSIF( REG_R9_Y_DOTS = '1' AND VDPR9PALMODE = '1' )THEN
-                        PREDOTCOUNTERYPSTART := "111010101";    -- TOP BORDER LINES = -43
-                    END IF;
-                    FF_MONITOR_LINE <= PREDOTCOUNTERYPSTART + W_Y_ADJ;
-                    PREWINDOW_Y_SP  <= '1';
-                ELSE
-                    IF( PREDOTCOUNTER_YP_V = 255 )THEN
-                        PREDOTCOUNTER_YP_V := FF_MONITOR_LINE;
+                IF( W_HSYNC = '1' )THEN
+                    -- JP: PREWINDOW_Xが 1になるタイミングと同じタイミングでY座標の計算
+                    IF(  W_V_BLANKING_END = '1' )THEN
+                        IF(    REG_R9_Y_DOTS = '0' AND VDPR9PALMODE = '0' )THEN
+                            PREDOTCOUNTERYPSTART := "111100110";    -- TOP BORDER LINES = -26
+                        ELSIF( REG_R9_Y_DOTS = '1' AND VDPR9PALMODE = '0' )THEN
+                            PREDOTCOUNTERYPSTART := "111110000";    -- TOP BORDER LINES = -16
+                        ELSIF( REG_R9_Y_DOTS = '0' AND VDPR9PALMODE = '1' )THEN
+                            PREDOTCOUNTERYPSTART := "111001011";    -- TOP BORDER LINES = -53
+                        ELSIF( REG_R9_Y_DOTS = '1' AND VDPR9PALMODE = '1' )THEN
+                            PREDOTCOUNTERYPSTART := "111010101";    -- TOP BORDER LINES = -43
+                        END IF;
+                        FF_MONITOR_LINE <= PREDOTCOUNTERYPSTART + W_Y_ADJ;
+                        PREWINDOW_Y_SP  <= '1';
                     ELSE
-                        PREDOTCOUNTER_YP_V := FF_MONITOR_LINE + 1;
+                        IF( PREDOTCOUNTER_YP_V = 255 )THEN
+                            PREDOTCOUNTER_YP_V := FF_MONITOR_LINE;
+                        ELSE
+                            PREDOTCOUNTER_YP_V := FF_MONITOR_LINE + 1;
+                        END IF;
+                        IF( PREDOTCOUNTER_YP_V = 0 ) THEN
+                            ENAHSYNC        <= '1';
+                            PREWINDOW_Y     <= '1';
+                        ELSIF( (REG_R9_Y_DOTS = '0' AND PREDOTCOUNTER_YP_V = 192) OR
+                               (REG_R9_Y_DOTS = '1' AND PREDOTCOUNTER_YP_V = 212) )THEN
+                            PREWINDOW_Y     <= '0';
+                            PREWINDOW_Y_SP  <= '0';
+                        ELSIF( (REG_R9_Y_DOTS = '0' AND VDPR9PALMODE = '0' AND PREDOTCOUNTER_YP_V = 235) OR
+                               (REG_R9_Y_DOTS = '1' AND VDPR9PALMODE = '0' AND PREDOTCOUNTER_YP_V = 245) OR
+                               (REG_R9_Y_DOTS = '0' AND VDPR9PALMODE = '1' AND PREDOTCOUNTER_YP_V = 259) OR
+                               (REG_R9_Y_DOTS = '1' AND VDPR9PALMODE = '1' AND PREDOTCOUNTER_YP_V = 269) )THEN
+                            ENAHSYNC        <= '0';
+                        END IF;
+                        FF_MONITOR_LINE <= PREDOTCOUNTER_YP_V;
                     END IF;
-                    IF( PREDOTCOUNTER_YP_V = 0 ) THEN
-                        ENAHSYNC        <= '1';
-                        PREWINDOW_Y     <= '1';
-                    ELSIF( (REG_R9_Y_DOTS = '0' AND PREDOTCOUNTER_YP_V = 192) OR
-                           (REG_R9_Y_DOTS = '1' AND PREDOTCOUNTER_YP_V = 212) )THEN
-                        PREWINDOW_Y     <= '0';
-                        PREWINDOW_Y_SP  <= '0';
-                    ELSIF( (REG_R9_Y_DOTS = '0' AND VDPR9PALMODE = '0' AND PREDOTCOUNTER_YP_V = 235) OR
-                           (REG_R9_Y_DOTS = '1' AND VDPR9PALMODE = '0' AND PREDOTCOUNTER_YP_V = 245) OR
-                           (REG_R9_Y_DOTS = '0' AND VDPR9PALMODE = '1' AND PREDOTCOUNTER_YP_V = 259) OR
-                           (REG_R9_Y_DOTS = '1' AND VDPR9PALMODE = '1' AND PREDOTCOUNTER_YP_V = 269) )THEN
-                        ENAHSYNC        <= '0';
-                    END IF;
-                    FF_MONITOR_LINE <= PREDOTCOUNTER_YP_V;
                 END IF;
-            END IF;
 
-            FF_PRE_Y_CNT <= FF_MONITOR_LINE + ("0" & REG_R23_VSTART_LINE);
+                FF_PRE_Y_CNT <= FF_MONITOR_LINE + ("0" & REG_R23_VSTART_LINE);
+            END IF;
         END IF;
     END PROCESS;
 

--- a/VIDEO/vdp_text12.vhd
+++ b/VIDEO/vdp_text12.vhd
@@ -189,21 +189,23 @@ BEGIN
     ---------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            DOTCOUNTER24    <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "10" )THEN
-                IF( DOTCOUNTERX = 12 )THEN
-                    -- JP: DOTCOUNTERは"10"のタイミングでは既にカウントアップしているので注意
-                    DOTCOUNTER24 <= (OTHERS => '0');
-                ELSE
-                    -- THE DOTCOUNTER24(2 DOWNTO 0) COUNTS UP 0 TO 5,
-                    -- AND THE DOTCOUNTER24(4 DOWNTO 3) COUNTS UP 0 TO 3.
-                    IF( DOTCOUNTER24(2 DOWNTO 0) = "101" ) THEN
-                        DOTCOUNTER24(4 DOWNTO 3) <= DOTCOUNTER24(4 DOWNTO 3) + 1;
-                        DOTCOUNTER24(2 DOWNTO 0) <= "000";
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                DOTCOUNTER24    <= (OTHERS => '0');
+	    ELSE
+                IF( DOTSTATE = "10" )THEN
+                    IF( DOTCOUNTERX = 12 )THEN
+                        -- JP: DOTCOUNTERは"10"のタイミングでは既にカウントアップしているので注意
+                        DOTCOUNTER24 <= (OTHERS => '0');
                     ELSE
-                        DOTCOUNTER24(2 DOWNTO 0) <= DOTCOUNTER24(2 DOWNTO 0) + 1;
+                        -- THE DOTCOUNTER24(2 DOWNTO 0) COUNTS UP 0 TO 5,
+                        -- AND THE DOTCOUNTER24(4 DOWNTO 3) COUNTS UP 0 TO 3.
+                        IF( DOTCOUNTER24(2 DOWNTO 0) = "101" ) THEN
+                            DOTCOUNTER24(4 DOWNTO 3) <= DOTCOUNTER24(4 DOWNTO 3) + 1;
+                            DOTCOUNTER24(2 DOWNTO 0) <= "000";
+                        ELSE
+                            DOTCOUNTER24(2 DOWNTO 0) <= DOTCOUNTER24(2 DOWNTO 0) + 1;
+                        END IF;
                     END IF;
                 END IF;
             END IF;
@@ -212,14 +214,16 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            TXPREWINDOWX    <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "10" )THEN
-                IF( DOTCOUNTERX = 12 )THEN
-                    TXPREWINDOWX <= '1';
-                ELSIF( DOTCOUNTERX = 240+12 )THEN
-                    TXPREWINDOWX <= '0';
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                TXPREWINDOWX    <= '0';
+	    ELSE
+                IF( DOTSTATE = "10" )THEN
+                    IF( DOTCOUNTERX = 12 )THEN
+                        TXPREWINDOWX <= '1';
+                    ELSIF( DOTCOUNTERX = 240+12 )THEN
+                        TXPREWINDOWX <= '0';
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -227,14 +231,16 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            TXWINDOWX       <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( DOTSTATE = "01" )THEN
-                IF( DOTCOUNTERX = 16 )THEN
-                    TXWINDOWX <= '1';
-                ELSIF( DOTCOUNTERX = 240+16 )THEN
-                    TXWINDOWX <= '0';
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                TXWINDOWX       <= '0';
+	    ELSE
+                IF( DOTSTATE = "01" )THEN
+                    IF( DOTCOUNTERX = 16 )THEN
+                        TXWINDOWX <= '1';
+                    ELSIF( DOTCOUNTERX = 240+16 )THEN
+                        TXWINDOWX <= '0';
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -245,94 +251,96 @@ BEGIN
     ---------------------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            PATTERNNUM                  <= (OTHERS => '0');
-            PRAMADR                     <= (OTHERS => '0');
-            ITXVRAMREADEN               <= '0';
-            ITXVRAMREADEN2              <= '0';
-            TXCHARCOUNTERX              <= (OTHERS => '0');
-            PREBLINK                    <= (OTHERS => '0');
-            TXCHARCOUNTERSTARTOFLINE    <= (OTHERS => '0');
-        ELSIF (CLK21M'EVENT AND CLK21M = '1') THEN
-            CASE DOTSTATE IS
-                WHEN "11" =>
-                    IF( TXPREWINDOWX = '1' ) THEN
-                        -- VRAM READ ADDRESS OUTPUT.
-                        CASE DOTCOUNTER24(2 DOWNTO 0) IS
-                            WHEN "000" =>
-                                IF( DOTCOUNTER24(4 DOWNTO 3) = "00" ) THEN
-                                    -- READ COLOR TABLE(TEXT2 BLINK)
-                                    -- IT IS USED ONLY ONE TIME PER 8 CHARACTERS.
-                                    PRAMADR <= LOGICALVRAMADDRCOL;
-                                    ITXVRAMREADEN2 <= '1';
-                                END IF;
-                            WHEN "001" =>
-                                -- READ PATTERN NAME TABLE
-                                PRAMADR <= LOGICALVRAMADDRNAM;
-                                ITXVRAMREADEN <= '1';
-                                TXCHARCOUNTERX <= TXCHARCOUNTERX + 1;
-                            WHEN "010" =>
-                                -- READ PATTERN GENERATOR TABLE
-                                PRAMADR <= LOGICALVRAMADDRGEN;
-                                ITXVRAMREADEN <= '1';
-                            WHEN "100" =>
-                                -- READ PATTERN NAME TABLE
-                                -- IT IS USED IF VDPMODE IS TEST2.
-                                PRAMADR <= LOGICALVRAMADDRNAM;
-                                ITXVRAMREADEN2 <= '1';
-                                IF( VDPMODETEXT2 = '1' ) THEN
+        IF ( RISING_EDGE(CLK21M) ) THEN
+            IF( RESET = '1' )THEN
+                PATTERNNUM                  <= (OTHERS => '0');
+                PRAMADR                     <= (OTHERS => '0');
+                ITXVRAMREADEN               <= '0';
+                ITXVRAMREADEN2              <= '0';
+                TXCHARCOUNTERX              <= (OTHERS => '0');
+                PREBLINK                    <= (OTHERS => '0');
+                TXCHARCOUNTERSTARTOFLINE    <= (OTHERS => '0');
+	    ELSE
+                CASE DOTSTATE IS
+                    WHEN "11" =>
+                        IF( TXPREWINDOWX = '1' ) THEN
+                            -- VRAM READ ADDRESS OUTPUT.
+                            CASE DOTCOUNTER24(2 DOWNTO 0) IS
+                                WHEN "000" =>
+                                    IF( DOTCOUNTER24(4 DOWNTO 3) = "00" ) THEN
+                                        -- READ COLOR TABLE(TEXT2 BLINK)
+                                        -- IT IS USED ONLY ONE TIME PER 8 CHARACTERS.
+                                        PRAMADR <= LOGICALVRAMADDRCOL;
+                                        ITXVRAMREADEN2 <= '1';
+                                    END IF;
+                                WHEN "001" =>
+                                    -- READ PATTERN NAME TABLE
+                                    PRAMADR <= LOGICALVRAMADDRNAM;
+                                    ITXVRAMREADEN <= '1';
                                     TXCHARCOUNTERX <= TXCHARCOUNTERX + 1;
+                                WHEN "010" =>
+                                    -- READ PATTERN GENERATOR TABLE
+                                    PRAMADR <= LOGICALVRAMADDRGEN;
+                                    ITXVRAMREADEN <= '1';
+                                WHEN "100" =>
+                                    -- READ PATTERN NAME TABLE
+                                    -- IT IS USED IF VDPMODE IS TEST2.
+                                    PRAMADR <= LOGICALVRAMADDRNAM;
+                                    ITXVRAMREADEN2 <= '1';
+                                    IF( VDPMODETEXT2 = '1' ) THEN
+                                        TXCHARCOUNTERX <= TXCHARCOUNTERX + 1;
+                                    END IF;
+                                WHEN "101" =>
+                                    -- READ PATTERN GENERATOR TABLE
+                                    -- IT IS USED IF VDPMODE IS TEST2.
+                                    PRAMADR <= LOGICALVRAMADDRGEN;
+                                    ITXVRAMREADEN2 <= '1';
+                                WHEN OTHERS =>
+                                    NULL;
+                            END CASE;
+                        END IF;
+                    WHEN "10" =>
+                        ITXVRAMREADEN <= '0';
+                        ITXVRAMREADEN2 <= '0';
+                    WHEN "00" =>
+                        IF( DOTCOUNTERX = 11) THEN
+                            TXCHARCOUNTERX <= (OTHERS => '0');
+                            IF( DOTCOUNTERY = 0 )   THEN
+                                TXCHARCOUNTERSTARTOFLINE <= (OTHERS => '0');
+                            END IF;
+                        ELSIF( (DOTCOUNTERX = 240+11) AND (DOTCOUNTERY(2 DOWNTO 0) = "111") ) THEN
+                                TXCHARCOUNTERSTARTOFLINE <= TXCHARCOUNTERSTARTOFLINE + TXCHARCOUNTERX;
+                        END IF;
+                    WHEN "01" =>
+                        CASE DOTCOUNTER24(2 DOWNTO 0) IS
+                            WHEN "001" =>
+                                -- READ COLOR TABLE(TEXT2 BLINK)
+                                -- IT IS USED ONLY ONE TIME PER 8 CHARACTERS.
+                                IF( DOTCOUNTER24(4 DOWNTO 3) = "00" ) THEN
+                                    PREBLINK <= PRAMDAT;
                                 END IF;
+                            WHEN "010" =>
+                                -- READ PATTERN NAME TABLE
+                                PATTERNNUM <= PRAMDAT;
+                            WHEN "011" =>
+                                -- READ PATTERN GENERATOR TABLE
+                                PREPATTERN <= PRAMDAT;
                             WHEN "101" =>
+                                -- READ PATTERN NAME TABLE
+                                -- IT IS USED IF VDPMODE IS TEST2.
+                                PATTERNNUM <= PRAMDAT;
+                            WHEN "000" =>
                                 -- READ PATTERN GENERATOR TABLE
                                 -- IT IS USED IF VDPMODE IS TEST2.
-                                PRAMADR <= LOGICALVRAMADDRGEN;
-                                ITXVRAMREADEN2 <= '1';
+                                IF( VDPMODETEXT2 = '1' ) THEN
+                                    PREPATTERN <= PRAMDAT;
+                                END IF;
                             WHEN OTHERS =>
                                 NULL;
                         END CASE;
-                    END IF;
-                WHEN "10" =>
-                    ITXVRAMREADEN <= '0';
-                    ITXVRAMREADEN2 <= '0';
-                WHEN "00" =>
-                    IF( DOTCOUNTERX = 11) THEN
-                        TXCHARCOUNTERX <= (OTHERS => '0');
-                        IF( DOTCOUNTERY = 0 )   THEN
-                            TXCHARCOUNTERSTARTOFLINE <= (OTHERS => '0');
-                        END IF;
-                    ELSIF( (DOTCOUNTERX = 240+11) AND (DOTCOUNTERY(2 DOWNTO 0) = "111") ) THEN
-                            TXCHARCOUNTERSTARTOFLINE <= TXCHARCOUNTERSTARTOFLINE + TXCHARCOUNTERX;
-                    END IF;
-                WHEN "01" =>
-                    CASE DOTCOUNTER24(2 DOWNTO 0) IS
-                        WHEN "001" =>
-                            -- READ COLOR TABLE(TEXT2 BLINK)
-                            -- IT IS USED ONLY ONE TIME PER 8 CHARACTERS.
-                            IF( DOTCOUNTER24(4 DOWNTO 3) = "00" ) THEN
-                                PREBLINK <= PRAMDAT;
-                            END IF;
-                        WHEN "010" =>
-                            -- READ PATTERN NAME TABLE
-                            PATTERNNUM <= PRAMDAT;
-                        WHEN "011" =>
-                            -- READ PATTERN GENERATOR TABLE
-                            PREPATTERN <= PRAMDAT;
-                        WHEN "101" =>
-                            -- READ PATTERN NAME TABLE
-                            -- IT IS USED IF VDPMODE IS TEST2.
-                            PATTERNNUM <= PRAMDAT;
-                        WHEN "000" =>
-                            -- READ PATTERN GENERATOR TABLE
-                            -- IT IS USED IF VDPMODE IS TEST2.
-                            IF( VDPMODETEXT2 = '1' ) THEN
-                                PREPATTERN <= PRAMDAT;
-                            END IF;
-                        WHEN OTHERS =>
-                            NULL;
-                    END CASE;
-                WHEN OTHERS => NULL;
-            END CASE;
+                    WHEN OTHERS => NULL;
+                END CASE;
+            END IF;
         END IF;
     END PROCESS;
 
@@ -341,56 +349,58 @@ BEGIN
     ----------------------------------------------------------------
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF(RESET = '1' ) THEN
-            PATTERN         <= (OTHERS => '0');
-            TXCOLORCODE     <= '0';
-            BLINK           <= (OTHERS => '0');
-        ELSIF (CLK21M'EVENT AND CLK21M = '1') THEN
-            -- COLOR CODE DECISION
-            -- JP: "01"と"10"のタイミングでかラーコードを出力してあげれば、
-            -- JP: VDPエンティティの方でパレットをデコードして色を出力してくれる。
-            -- JP: "01"と"10"で同じ色を出力すれば横256ドットになり、違う色を
-            -- JP: 出力すれば横512ドット表示となる。
-            CASE DOTSTATE IS
-                WHEN "00" =>
-                    IF( DOTCOUNTER24(2 DOWNTO 0) = "100" ) THEN
-                        -- LOAD NEXT 8 DOT DATA
-                        -- JP: キャラクタの描画は DOTCOUNTER24が、
-                        -- JP:   "0:4"から"1:3"の6ドット
-                        -- JP:   "1:4"から"2:3"の6ドット
-                        -- JP:   "2:4"から"3:3"の6ドット
-                        -- JP:   "3:4"から"0:3"の6ドット
-                        -- JP: で行われるので"100"のタイミングでロードする
-                        PATTERN <= PREPATTERN;
-                    ELSIF( (DOTCOUNTER24(2 DOWNTO 0) = "001") AND (VDPMODETEXT2 = '1') ) THEN
-                        -- JP: TEXT2では"001"のタイミングでもロードする。
-                        PATTERN <= PREPATTERN;
-                    END IF;
-                    IF( (DOTCOUNTER24(2 DOWNTO 0) = "100") OR
-                            (DOTCOUNTER24(2 DOWNTO 0) = "001") ) THEN
-                        -- EVALUATE BLINK SIGNAL
-                        IF(DOTCOUNTER24(4 DOWNTO 0) = "00100") THEN
-                            BLINK <= PREBLINK;
-                        ELSE
-                            BLINK <= BLINK(6 DOWNTO 0) & "0";
+        IF (RISING_EDGE(CLK21M)) THEN
+            IF(RESET = '1' ) THEN
+                PATTERN         <= (OTHERS => '0');
+                TXCOLORCODE     <= '0';
+                BLINK           <= (OTHERS => '0');
+	    ELSE
+                -- COLOR CODE DECISION
+                -- JP: "01"と"10"のタイミングでかラーコードを出力してあげれば、
+                -- JP: VDPエンティティの方でパレットをデコードして色を出力してくれる。
+                -- JP: "01"と"10"で同じ色を出力すれば横256ドットになり、違う色を
+                -- JP: 出力すれば横512ドット表示となる。
+                CASE DOTSTATE IS
+                    WHEN "00" =>
+                        IF( DOTCOUNTER24(2 DOWNTO 0) = "100" ) THEN
+                            -- LOAD NEXT 8 DOT DATA
+                            -- JP: キャラクタの描画は DOTCOUNTER24が、
+                            -- JP:   "0:4"から"1:3"の6ドット
+                            -- JP:   "1:4"から"2:3"の6ドット
+                            -- JP:   "2:4"から"3:3"の6ドット
+                            -- JP:   "3:4"から"0:3"の6ドット
+                            -- JP: で行われるので"100"のタイミングでロードする
+                            PATTERN <= PREPATTERN;
+                        ELSIF( (DOTCOUNTER24(2 DOWNTO 0) = "001") AND (VDPMODETEXT2 = '1') ) THEN
+                            -- JP: TEXT2では"001"のタイミングでもロードする。
+                            PATTERN <= PREPATTERN;
                         END IF;
-                    END IF;
-                WHEN "01" =>
-                    -- パターンに応じてカラーコードを決定
-                    TXCOLORCODE <= PATTERN(7);
-                    -- パターンをシフト
-                    PATTERN <= PATTERN(6 DOWNTO 0) & '0';
-                WHEN "11" =>
-                    NULL;
-                WHEN "10" =>
-                    IF( VDPMODETEXT2 = '1' ) THEN
+                        IF( (DOTCOUNTER24(2 DOWNTO 0) = "100") OR
+                                (DOTCOUNTER24(2 DOWNTO 0) = "001") ) THEN
+                            -- EVALUATE BLINK SIGNAL
+                            IF(DOTCOUNTER24(4 DOWNTO 0) = "00100") THEN
+                                BLINK <= PREBLINK;
+                            ELSE
+                                BLINK <= BLINK(6 DOWNTO 0) & "0";
+                            END IF;
+                        END IF;
+                    WHEN "01" =>
+                        -- パターンに応じてカラーコードを決定
                         TXCOLORCODE <= PATTERN(7);
                         -- パターンをシフト
                         PATTERN <= PATTERN(6 DOWNTO 0) & '0';
-                    END IF;
+                    WHEN "11" =>
+                        NULL;
+                    WHEN "10" =>
+                        IF( VDPMODETEXT2 = '1' ) THEN
+                            TXCOLORCODE <= PATTERN(7);
+                            -- パターンをシフト
+                            PATTERN <= PATTERN(6 DOWNTO 0) & '0';
+                        END IF;
 
-                WHEN OTHERS => NULL;
-            END CASE;
+                    WHEN OTHERS => NULL;
+                END CASE;
+            END IF;
         END IF;
     END PROCESS;
 
@@ -404,14 +414,16 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_BLINK_FRAME_CNT <= (OTHERS => '0');
-        ELSIF (CLK21M'EVENT AND CLK21M = '1') THEN
-            IF( W_FRAME_SYNC = '1' )THEN
-                IF (FF_BLINK_FRAME_CNT = "1001") THEN
-                    FF_BLINK_FRAME_CNT <= (OTHERS => '0');
-                ELSE
-                    FF_BLINK_FRAME_CNT <= FF_BLINK_FRAME_CNT + 1;
+        IF (RISING_EDGE(CLK21M)) THEN
+            IF( RESET = '1' )THEN
+                FF_BLINK_FRAME_CNT <= (OTHERS => '0');
+	    ELSE
+                IF( W_FRAME_SYNC = '1' )THEN
+                    IF (FF_BLINK_FRAME_CNT = "1001") THEN
+                        FF_BLINK_FRAME_CNT <= (OTHERS => '0');
+                    ELSE
+                        FF_BLINK_FRAME_CNT <= FF_BLINK_FRAME_CNT + 1;
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -419,18 +431,20 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_BLINK_STATE <= '0';
-        ELSIF (CLK21M'EVENT AND CLK21M = '1') THEN
-            IF( (W_FRAME_SYNC = '1') AND (FF_BLINK_FRAME_CNT = "1001") )THEN
-                IF(    REG_R13_BLINK_PERIOD( 7 DOWNTO 4 ) = "0000" )THEN
-                    -- WHEN ON PERIOD IS 0, THE BLINK COLOR IS ALWAYS OFF
-                    FF_BLINK_STATE <= '0';
-                ELSIF( REG_R13_BLINK_PERIOD( 3 DOWNTO 0 ) = "0000" )THEN
-                    -- WHEN OFF PERIOD IS 0, THE BLINK COLOR IS ALWAYS ON
-                    FF_BLINK_STATE <= '1';
-                ELSIF( FF_BLINK_PERIOD_CNT >= W_BLINK_CNT_MAX )THEN
-                    FF_BLINK_STATE <= NOT FF_BLINK_STATE;
+        IF (RISING_EDGE(CLK21M)) THEN
+            IF( RESET = '1' )THEN
+                FF_BLINK_STATE <= '0';
+	    ELSE
+                IF( (W_FRAME_SYNC = '1') AND (FF_BLINK_FRAME_CNT = "1001") )THEN
+                    IF(    REG_R13_BLINK_PERIOD( 7 DOWNTO 4 ) = "0000" )THEN
+                        -- WHEN ON PERIOD IS 0, THE BLINK COLOR IS ALWAYS OFF
+                        FF_BLINK_STATE <= '0';
+                    ELSIF( REG_R13_BLINK_PERIOD( 3 DOWNTO 0 ) = "0000" )THEN
+                        -- WHEN OFF PERIOD IS 0, THE BLINK COLOR IS ALWAYS ON
+                        FF_BLINK_STATE <= '1';
+                    ELSIF( FF_BLINK_PERIOD_CNT >= W_BLINK_CNT_MAX )THEN
+                        FF_BLINK_STATE <= NOT FF_BLINK_STATE;
+                    END IF;
                 END IF;
             END IF;
         END IF;
@@ -438,14 +452,16 @@ BEGIN
 
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_BLINK_PERIOD_CNT <= (OTHERS => '0');
-        ELSIF (CLK21M'EVENT AND CLK21M = '1') THEN
-            IF( (W_FRAME_SYNC = '1') AND (FF_BLINK_FRAME_CNT = "1001") )THEN
-                IF( FF_BLINK_PERIOD_CNT >= W_BLINK_CNT_MAX )THEN
-                    FF_BLINK_PERIOD_CNT <= (OTHERS => '0');
-                ELSE
-                    FF_BLINK_PERIOD_CNT <= FF_BLINK_PERIOD_CNT + 1;
+        IF (RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                FF_BLINK_PERIOD_CNT <= (OTHERS => '0');
+	    ELSE
+                IF( (W_FRAME_SYNC = '1') AND (FF_BLINK_FRAME_CNT = "1001") )THEN
+                    IF( FF_BLINK_PERIOD_CNT >= W_BLINK_CNT_MAX )THEN
+                        FF_BLINK_PERIOD_CNT <= (OTHERS => '0');
+                    ELSE
+                        FF_BLINK_PERIOD_CNT <= FF_BLINK_PERIOD_CNT + 1;
+                    END IF;
                 END IF;
             END IF;
         END IF;

--- a/VIDEO/vdp_vga.vhd
+++ b/VIDEO/vdp_vga.vhd
@@ -189,13 +189,15 @@ BEGIN
     -- GENERATE H-SYNC SIGNAL
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            FF_HSYNC_N <= '1';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( (HCOUNTERIN = 0) OR (HCOUNTERIN = (CLOCKS_PER_LINE/2)) ) THEN
-                FF_HSYNC_N <= '0';
-            ELSIF( (HCOUNTERIN = 40) OR (HCOUNTERIN = (CLOCKS_PER_LINE/2) + 40) ) THEN
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
                 FF_HSYNC_N <= '1';
+	    ELSE
+                IF( (HCOUNTERIN = 0) OR (HCOUNTERIN = (CLOCKS_PER_LINE/2)) ) THEN
+                    FF_HSYNC_N <= '0';
+                ELSIF( (HCOUNTERIN = 40) OR (HCOUNTERIN = (CLOCKS_PER_LINE/2) + 40) ) THEN
+                    FF_HSYNC_N <= '1';
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -204,35 +206,37 @@ BEGIN
     -- THE VIDEOVSIN_N SIGNAL IS NOT USED
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            VIDEOVSOUT_N <= '1';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF ( PALMODE = '0' ) THEN -- caro
-                IF( INTERLACEMODE = '0' ) THEN
-                    IF( (VCOUNTERIN = 3*2) OR (VCOUNTERIN = 524+3*2) )THEN
-                        VIDEOVSOUT_N <= '0';
-                    ELSIF( (VCOUNTERIN = 6*2) OR (VCOUNTERIN = 524+6*2) ) THEN
-                        VIDEOVSOUT_N <= '1';
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
+                VIDEOVSOUT_N <= '1';
+	    ELSE
+                IF ( PALMODE = '0' ) THEN -- caro
+                    IF( INTERLACEMODE = '0' ) THEN
+                        IF( (VCOUNTERIN = 3*2) OR (VCOUNTERIN = 524+3*2) )THEN
+                            VIDEOVSOUT_N <= '0';
+                        ELSIF( (VCOUNTERIN = 6*2) OR (VCOUNTERIN = 524+6*2) ) THEN
+                            VIDEOVSOUT_N <= '1';
+                        END IF;
+                    ELSE
+                        IF( (VCOUNTERIN = 3*2) OR (VCOUNTERIN = 525+3*2) )THEN
+                            VIDEOVSOUT_N <= '0';
+                        ELSIF( (VCOUNTERIN = 6*2) OR (VCOUNTERIN = 525+6*2) ) THEN
+                            VIDEOVSOUT_N <= '1';
+                        END IF;
                     END IF;
                 ELSE
-                    IF( (VCOUNTERIN = 3*2) OR (VCOUNTERIN = 525+3*2) )THEN
-                        VIDEOVSOUT_N <= '0';
-                    ELSIF( (VCOUNTERIN = 6*2) OR (VCOUNTERIN = 525+6*2) ) THEN
-                        VIDEOVSOUT_N <= '1';
-                    END IF;
-                END IF;
-            ELSE
-                IF( INTERLACEMODE = '0' ) THEN
-                    IF( (VCOUNTERIN = 3*2) OR (VCOUNTERIN = 626+3*2) )THEN
-                        VIDEOVSOUT_N <= '0';
-                    ELSIF( (VCOUNTERIN = 6*2) OR (VCOUNTERIN = 626+6*2) ) THEN
-                        VIDEOVSOUT_N <= '1';
-                    END IF;
-                ELSE
-                    IF( (VCOUNTERIN = 3*2) OR (VCOUNTERIN = 625+3*2) )THEN
-                        VIDEOVSOUT_N <= '0';
-                    ELSIF( (VCOUNTERIN = 6*2) OR (VCOUNTERIN = 625+6*2) ) THEN
-                        VIDEOVSOUT_N <= '1';
+                    IF( INTERLACEMODE = '0' ) THEN
+                        IF( (VCOUNTERIN = 3*2) OR (VCOUNTERIN = 626+3*2) )THEN
+                            VIDEOVSOUT_N <= '0';
+                        ELSIF( (VCOUNTERIN = 6*2) OR (VCOUNTERIN = 626+6*2) ) THEN
+                            VIDEOVSOUT_N <= '1';
+                        END IF;
+                    ELSE
+                        IF( (VCOUNTERIN = 3*2) OR (VCOUNTERIN = 625+3*2) )THEN
+                            VIDEOVSOUT_N <= '0';
+                        ELSIF( (VCOUNTERIN = 6*2) OR (VCOUNTERIN = 625+6*2) ) THEN
+                            VIDEOVSOUT_N <= '1';
+                        END IF;
                     END IF;
                 END IF;
             END IF;
@@ -242,14 +246,16 @@ BEGIN
     -- GENERATE DATA READ TIMING
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            XPOSITIONR <= (OTHERS => '0');
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( (HCOUNTERIN = DISP_START_X) OR
-                    (HCOUNTERIN = DISP_START_X + (CLOCKS_PER_LINE/2)) ) THEN
+        IF( RISING_EDGE(CLK21M) )THEN
+            IF( RESET = '1' )THEN
                 XPOSITIONR <= (OTHERS => '0');
-            ELSE
-                XPOSITIONR <= XPOSITIONR + 1;
+	    ELSE
+                IF( (HCOUNTERIN = DISP_START_X) OR
+                        (HCOUNTERIN = DISP_START_X + (CLOCKS_PER_LINE/2)) ) THEN
+                    XPOSITIONR <= (OTHERS => '0');
+                ELSE
+                    XPOSITIONR <= XPOSITIONR + 1;
+                END IF;
             END IF;
         END IF;
     END PROCESS;
@@ -257,44 +263,46 @@ BEGIN
     -- GENERATE VIDEO OUTPUT TIMING
     PROCESS( RESET, CLK21M )
     BEGIN
-        IF( RESET = '1' )THEN
-            VIDEOOUTX <= '0';
-            VIDEOOUTY <= '0';
-        ELSIF( CLK21M'EVENT AND CLK21M = '1' )THEN
-            IF( (HCOUNTERIN = DISP_START_X) OR
-                    ((HCOUNTERIN = DISP_START_X + (CLOCKS_PER_LINE/2)) AND INTERLACEMODE = '0') ) THEN
-                VIDEOOUTX <= VIDEOOUTY;
-            ELSIF( (HCOUNTERIN = DISP_START_X + DISP_WIDTH) OR
-                       (HCOUNTERIN = DISP_START_X + DISP_WIDTH + (CLOCKS_PER_LINE/2)) ) THEN
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( RESET = '1' )THEN
                 VIDEOOUTX <= '0';
-            END IF;
-
-            IF( INTERLACEMODE='0' ) THEN
-                -- NON-INTERLACE
-                -- 3+3+16 = 19
-                IF( (VCOUNTERIN = 20*2) OR
-                        ((VCOUNTERIN = 524+20*2) AND (PALMODE = '0')) OR
-                        ((VCOUNTERIN = 626+20*2) AND (PALMODE = '1')) ) THEN
-                    VIDEOOUTY <= '1';
-                ELSIF(  ((VCOUNTERIN = 524) AND (PALMODE = '0')) OR
-                        ((VCOUNTERIN = 626) AND (PALMODE = '1')) OR
-                         (VCOUNTERIN = 0) ) THEN
-                    VIDEOOUTY <= '0';
+                VIDEOOUTY <= '0';
+	    ELSE
+                IF( (HCOUNTERIN = DISP_START_X) OR
+                        ((HCOUNTERIN = DISP_START_X + (CLOCKS_PER_LINE/2)) AND INTERLACEMODE = '0') ) THEN
+                    VIDEOOUTX <= VIDEOOUTY;
+                ELSIF( (HCOUNTERIN = DISP_START_X + DISP_WIDTH) OR
+                           (HCOUNTERIN = DISP_START_X + DISP_WIDTH + (CLOCKS_PER_LINE/2)) ) THEN
+                    VIDEOOUTX <= '0';
                 END IF;
-            ELSE
-                -- INTERLACE
-                IF( (VCOUNTERIN = 20*2) OR
-                        -- +1 SHOULD BE NEEDED.
-                        -- BECAUSE ODD FIELD'S START IS DELAYED HALF LINE.
-                        -- SO THE START POSITION OF DISPLAY TIME SHOULD BE
-                        -- DELAYED MORE HALF LINE.
-                        ((VCOUNTERIN = 525+20*2 + 1) AND (PALMODE = '0')) OR
-                        ((VCOUNTERIN = 625+20*2 + 1) AND (PALMODE = '1')) ) THEN
-                    VIDEOOUTY <= '1';
-                ELSIF(  ((VCOUNTERIN = 525) AND (PALMODE = '0')) OR
-                        ((VCOUNTERIN = 625) AND (PALMODE = '1')) OR
-                         (VCOUNTERIN = 0) ) THEN
-                    VIDEOOUTY <= '0';
+
+                IF( INTERLACEMODE='0' ) THEN
+                    -- NON-INTERLACE
+                    -- 3+3+16 = 19
+                    IF( (VCOUNTERIN = 20*2) OR
+                            ((VCOUNTERIN = 524+20*2) AND (PALMODE = '0')) OR
+                            ((VCOUNTERIN = 626+20*2) AND (PALMODE = '1')) ) THEN
+                        VIDEOOUTY <= '1';
+                    ELSIF(  ((VCOUNTERIN = 524) AND (PALMODE = '0')) OR
+                            ((VCOUNTERIN = 626) AND (PALMODE = '1')) OR
+                             (VCOUNTERIN = 0) ) THEN
+                        VIDEOOUTY <= '0';
+                    END IF;
+                ELSE
+                    -- INTERLACE
+                    IF( (VCOUNTERIN = 20*2) OR
+                            -- +1 SHOULD BE NEEDED.
+                            -- BECAUSE ODD FIELD'S START IS DELAYED HALF LINE.
+                            -- SO THE START POSITION OF DISPLAY TIME SHOULD BE
+                            -- DELAYED MORE HALF LINE.
+                            ((VCOUNTERIN = 525+20*2 + 1) AND (PALMODE = '0')) OR
+                            ((VCOUNTERIN = 625+20*2 + 1) AND (PALMODE = '1')) ) THEN
+                        VIDEOOUTY <= '1';
+                    ELSIF(  ((VCOUNTERIN = 525) AND (PALMODE = '0')) OR
+                            ((VCOUNTERIN = 625) AND (PALMODE = '1')) OR
+                             (VCOUNTERIN = 0) ) THEN
+                        VIDEOOUTY <= '0';
+                    END IF;
                 END IF;
             END IF;
         END IF;

--- a/VIDEO/vdp_vga.vhd
+++ b/VIDEO/vdp_vga.vhd
@@ -58,38 +58,40 @@
 -------------------------------------------------------------------------------
 -- Memo
 --   Japanese comment lines are starts with "JP:".
---   JP: ï¿½ï¿½ï¿½{ï¿½ï¿½ï¿½ÌƒRï¿½ï¿½ï¿½ï¿½ï¿½gï¿½sï¿½ï¿½ JP:ï¿½ð“ª‚É•tï¿½ï¿½ï¿½éŽ–ï¿½É‚ï¿½ï¿½ï¿½
+--   JP: “ú–{Œê‚ÌƒRƒƒ“ƒgs‚Í JP:‚ð“ª‚É•t‚¯‚éŽ–‚É‚·‚é
 --
 -------------------------------------------------------------------------------
 -- Revision History
 --
--- 29th,October,2006 modified by Kunihiko Ohnaka
---   - Insert the license text.
---   - Add the document part below.
+-- 3rd,June,2018 modified by KdL
+--  - Added a trick to help set a pixel ratio 1:1
+--    on an LED display at 60Hz (not guaranteed on all displays)
 --
--- ?th,August,2006 modified by Kunihiko Ohnaka
---   - Move the equalization pulse generator from
---     vdp.vhd.
+-- 29th,October,2006 modified by Kunihiko Ohnaka
+--  - Inserted the license text
+--  - Added the document part below
+--
+-- ??th,August,2006 modified by Kunihiko Ohnaka
+--  - Moved the equalization pulse generator from vdp.vhd
 --
 -- 20th,August,2006 modified by Kunihiko Ohnaka
---  - Change field mapping algorithm when interlace
---    mode is enabled.
---        even field  -> even line (odd  line is blacK)
---        odd  field  -> odd line  (even line is blacK)
+--  - Changed field mapping algorithm when interlace mode is enabled
+--        even field  -> even line (odd  line is black)
+--        odd  field  -> odd line  (even line is black)
 --
 -- 13th,October,2003 created by Kunihiko Ohnaka
--- JP: VDPï¿½ÌƒRï¿½Aï¿½ÌŽï¿½ï¿½ï¿½Æ•\ï¿½ï¿½ï¿½fï¿½oï¿½Cï¿½Xï¿½Ö‚Ìoï¿½Í‚ï¿½ï¿½Êƒ\ï¿½[ï¿½Xï¿½É‚ï¿½ï¿½ï¿½ï¿½D
+-- JP: VDP‚ÌƒRƒA‚ÌŽÀ‘•‚Æ•\Ž¦ƒfƒoƒCƒX‚Ö‚Ìo—Í‚ð•Êƒ\[ƒX‚É‚µ‚½D
 --
 -------------------------------------------------------------------------------
 -- Document
 --
--- JP: ESE-VDPï¿½Rï¿½A(vdp.vhd)ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½rï¿½fï¿½Iï¿½Mï¿½ï¿½ï¿½ï¿½ï¿½AVGAï¿½^ï¿½Cï¿½~ï¿½ï¿½ï¿½Oï¿½ï¿½
--- JP: ï¿½ÏŠï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Aï¿½bï¿½vï¿½Xï¿½Lï¿½ï¿½ï¿½ï¿½ï¿½Rï¿½ï¿½ï¿½oï¿½[ï¿½^ï¿½Å‚ï¿½ï¿½B
--- JP: NTSCï¿½Íï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½15.7KHzï¿½Aï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½60Hzï¿½Å‚ï¿½ï¿½ï¿½ï¿½A
--- JP: VGAï¿½Ìï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½31.5KHzï¿½Aï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½60Hzï¿½Å‚ï¿½ï¿½ï¿½ï¿½A
--- JP: ï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ù‚Ú”{ï¿½É‚È‚ï¿½ï¿½ï¿½æ‚¤ï¿½Èƒ^ï¿½Cï¿½~ï¿½ï¿½ï¿½Oï¿½É‚È‚ï¿½ï¿½Ü‚ï¿½ï¿½B
--- JP: ï¿½ï¿½ï¿½ï¿½ï¿½ÅAvdpï¿½ï¿½ ntscï¿½ï¿½ï¿½[ï¿½hï¿½Å“ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Aï¿½eï¿½ï¿½ï¿½Cï¿½ï¿½ï¿½ï¿½ï¿½{ï¿½Ì‘ï¿½ï¿½xï¿½ï¿½
--- JP: ï¿½ï¿½ï¿½xï¿½`ï¿½æ‚·ï¿½é‚±ï¿½Æ‚ÅƒXï¿½Lï¿½ï¿½ï¿½ï¿½ï¿½Rï¿½ï¿½ï¿½oï¿½[ï¿½gï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ü‚ï¿½ï¿½B
+-- JP: ESE-VDPƒRƒA(vdp.vhd)‚ª¶¬‚µ‚½ƒrƒfƒIM†‚ðAVGAƒ^ƒCƒ~ƒ“ƒO‚É
+-- JP: •ÏŠ·‚·‚éƒAƒbƒvƒXƒLƒƒƒ“ƒRƒ“ƒo[ƒ^‚Å‚·B
+-- JP: NTSC‚Í…•½“¯ŠúŽü”g”‚ª15.7KHzA‚’¼“¯ŠúŽü”g”‚ª60Hz‚Å‚·‚ªA
+-- JP: VGA‚Ì…•½“¯ŠúŽü”g”‚Í31.5KHzA‚’¼“¯ŠúŽü”g”‚Í60Hz‚Å‚ ‚èA
+-- JP: ƒ‰ƒCƒ“”‚¾‚¯‚ª‚Ù‚Ú”{‚É‚È‚Á‚½‚æ‚¤‚Èƒ^ƒCƒ~ƒ“ƒO‚É‚È‚è‚Ü‚·B
+-- JP: ‚»‚±‚ÅAvdp‚ð ntscƒ‚[ƒh‚Å“®‚©‚µAŠeƒ‰ƒCƒ“‚ð”{‚Ì‘¬“x‚Å
+-- JP: “ñ“x•`‰æ‚·‚é‚±‚Æ‚ÅƒXƒLƒƒƒ“ƒRƒ“ƒo[ƒg‚ðŽÀŒ»‚µ‚Ä‚¢‚Ü‚·B
 --
 
 LIBRARY IEEE;
@@ -159,8 +161,8 @@ ARCHITECTURE RTL OF VDP_VGA IS
     SIGNAL DATADEOUT        : STD_LOGIC;
 
     -- DISP_START_X + DISP_WIDTH < CLOCKS_PER_LINE/2 = 684
-    CONSTANT DISP_WIDTH     : INTEGER := 562;    -- 30 + 512 + 20
-    CONSTANT DISP_START_X   : INTEGER := 120;
+    CONSTANT DISP_WIDTH             : INTEGER := 576;
+    SHARED VARIABLE DISP_START_X    : INTEGER := 684 - DISP_WIDTH - 2;          -- 106
 BEGIN
 
     VIDEOROUT <= DATAROUT  WHEN VIDEOOUTX = '1' ELSE (OTHERS => '0');
@@ -185,6 +187,42 @@ BEGIN
     XPOSITIONW  <=  HCOUNTERIN(10 DOWNTO 1) - (CLOCKS_PER_LINE/2 - DISP_WIDTH - 10);
     EVENODD     <=  VCOUNTERIN(1);
     WE_BUF      <=  '1';
+
+    -- PIXEL RATIO 1:1 FOR LED DISPLAY
+    PROCESS( CLK21M )
+        CONSTANT DISP_START_Y   : INTEGER := 3;
+        CONSTANT PRB_HEIGHT     : INTEGER := 25;
+        CONSTANT RIGHT_X        : INTEGER := 684 - DISP_WIDTH - 2;              -- 106
+        CONSTANT PAL_RIGHT_X    : INTEGER := 87;                                -- 87
+        CONSTANT CENTER_X       : INTEGER := RIGHT_X - 32 - 2;                  -- 72
+        CONSTANT BASE_LEFT_X    : INTEGER := CENTER_X - 32 - 2 - 3;             -- 35
+    BEGIN
+        IF( CLK21M'EVENT AND CLK21M = '1' )THEN
+            IF( (RATIOMODE = "000" OR INTERLACEMODE = '1' OR PALMODE = '1') AND LEGACY_VGA = '1' )THEN
+                -- LEGACY OUTPUT
+                DISP_START_X := RIGHT_X;                                        -- 106
+            ELSIF( PALMODE = '1' )THEN
+                -- 50HZ
+                DISP_START_X := PAL_RIGHT_X;                                    -- 87
+            ELSIF( RATIOMODE = "000" OR INTERLACEMODE = '1' )THEN
+                -- 60HZ
+                DISP_START_X := CENTER_X;                                       -- 72
+            ELSIF( (VCOUNTERIN < 38 + DISP_START_Y + PRB_HEIGHT) OR
+                   (VCOUNTERIN > 526 - PRB_HEIGHT AND VCOUNTERIN < 526 ) OR
+                   (VCOUNTERIN > 524 + 38 + DISP_START_Y AND VCOUNTERIN < 524 + 38 + DISP_START_Y + PRB_HEIGHT) OR
+                   (VCOUNTERIN > 524 + 526 - PRB_HEIGHT) )THEN
+                -- PIXEL RATIO 1:1 (VGA MODE, 60HZ, NOT INTERLACED)
+--              IF( EVENODD = '0' )THEN                                         -- PLOT FROM TOP-RIGHT
+                IF( EVENODD = '1' )THEN                                         -- PLOT FROM TOP-LEFT
+                    DISP_START_X := BASE_LEFT_X + CONV_INTEGER(NOT RATIOMODE);  -- 35 TO 41
+                ELSE
+                    DISP_START_X := RIGHT_X;                                    -- 106
+                END IF;
+            ELSE
+                DISP_START_X := CENTER_X;                                       -- 72
+            END IF;
+        END IF;
+    END PROCESS;
 
     -- GENERATE H-SYNC SIGNAL
     PROCESS( RESET, CLK21M )

--- a/VIDEO/vdp_wait_control.vhd
+++ b/VIDEO/vdp_wait_control.vhd
@@ -135,66 +135,66 @@ BEGIN
     PROCESS( RESET, CLK21M )
     BEGIN
         IF( CLK21M'EVENT AND CLK21M = '1' )THEN
-        IF( RESET = '1' )THEN
-            FF_WAIT_CNT <= (OTHERS => '0');
-            ELSE
-            IF( DRIVE = '1' )THEN
-                -- 50Hz (PAL)
-                IF( VDPR9PALMODE = '1' )THEN
-                    -- Display On
-                    IF( REG_R1_DISP_ON = '1' )THEN
-                        -- Sprite On
-                        IF( REG_R8_SP_OFF = '0' )THEN
-                            -- 212 Lines
-                            IF( REG_R9_Y_DOTS = '1' )THEN
-                                FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_501( CONV_INTEGER( VDP_COMMAND ) );
-                            -- 192 Lines
-                            ELSE
-                                FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_502( CONV_INTEGER( VDP_COMMAND ) );
-                            END IF;
-                        -- Sprite Off
-                        ELSE
-                            -- 212 Lines
-                            IF( REG_R9_Y_DOTS = '1' )THEN
-                                FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_503( CONV_INTEGER( VDP_COMMAND ) );
-                            -- 192 Lines
-                            ELSE
-                                FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_504( CONV_INTEGER( VDP_COMMAND ) );
-                            END IF;
-                        END IF;
-                    -- Display Off (Blank)
-                    ELSE
-                        FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_505( CONV_INTEGER( VDP_COMMAND ) );
-                    END IF;
-                -- 60Hz (NTSC)
+            IF( RESET = '1' )THEN
+                FF_WAIT_CNT <= (OTHERS => '0');
                 ELSE
-                    -- Display On
-                    IF( REG_R1_DISP_ON = '1' )THEN
-                        -- Sprite On
-                        IF( REG_R8_SP_OFF = '0' )THEN
-                            -- 212 Lines
-                            IF( REG_R9_Y_DOTS = '1' )THEN
-                                FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_601( CONV_INTEGER( VDP_COMMAND ) );
-                            -- 192 Lines
+                IF( DRIVE = '1' )THEN
+                    -- 50Hz (PAL)
+                    IF( VDPR9PALMODE = '1' )THEN
+                        -- Display On
+                        IF( REG_R1_DISP_ON = '1' )THEN
+                            -- Sprite On
+                            IF( REG_R8_SP_OFF = '0' )THEN
+                                -- 212 Lines
+                                IF( REG_R9_Y_DOTS = '1' )THEN
+                                    FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_501( CONV_INTEGER( VDP_COMMAND ) );
+                                -- 192 Lines
+                                ELSE
+                                    FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_502( CONV_INTEGER( VDP_COMMAND ) );
+                                END IF;
+                            -- Sprite Off
                             ELSE
-                                FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_602( CONV_INTEGER( VDP_COMMAND ) );
+                                -- 212 Lines
+                                IF( REG_R9_Y_DOTS = '1' )THEN
+                                    FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_503( CONV_INTEGER( VDP_COMMAND ) );
+                                -- 192 Lines
+                                ELSE
+                                    FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_504( CONV_INTEGER( VDP_COMMAND ) );
+                                END IF;
                             END IF;
-                        -- Sprite Off
+                        -- Display Off (Blank)
                         ELSE
-                            -- 212 Lines
-                            IF( REG_R9_Y_DOTS = '1' )THEN
-                                FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_603( CONV_INTEGER( VDP_COMMAND ) );
-                            -- 192 Lines
-                            ELSE
-                                FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_604( CONV_INTEGER( VDP_COMMAND ) );
-                            END IF;
+                            FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_505( CONV_INTEGER( VDP_COMMAND ) );
                         END IF;
-                    -- Display Off (Blank)
+                    -- 60Hz (NTSC)
                     ELSE
-                        FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_605( CONV_INTEGER( VDP_COMMAND ) );
+                        -- Display On
+                        IF( REG_R1_DISP_ON = '1' )THEN
+                            -- Sprite On
+                            IF( REG_R8_SP_OFF = '0' )THEN
+                                -- 212 Lines
+                                IF( REG_R9_Y_DOTS = '1' )THEN
+                                    FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_601( CONV_INTEGER( VDP_COMMAND ) );
+                                -- 192 Lines
+                                ELSE
+                                    FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_602( CONV_INTEGER( VDP_COMMAND ) );
+                                END IF;
+                            -- Sprite Off
+                            ELSE
+                                -- 212 Lines
+                                IF( REG_R9_Y_DOTS = '1' )THEN
+                                    FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_603( CONV_INTEGER( VDP_COMMAND ) );
+                                -- 192 Lines
+                                ELSE
+                                    FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_604( CONV_INTEGER( VDP_COMMAND ) );
+                                END IF;
+                            END IF;
+                        -- Display Off (Blank)
+                        ELSE
+                            FF_WAIT_CNT <= ('0' & FF_WAIT_CNT(14 DOWNTO  0)) + C_WAIT_TABLE_605( CONV_INTEGER( VDP_COMMAND ) );
+                        END IF;
                     END IF;
                 END IF;
-            END IF;
             END IF;
         END IF;
     END PROCESS;

--- a/peripheral/kanji.vhd
+++ b/peripheral/kanji.vhd
@@ -34,7 +34,7 @@
 -- Fixed kanjiptr2 counter
 --
 -- 05th, April, 2008 modified by t.hara
--- ƒŠƒtƒ@ƒNƒ^ƒŠƒ“ƒOB
+-- ï¿½ï¿½ï¿½tï¿½@ï¿½Nï¿½^ï¿½ï¿½ï¿½ï¿½ï¿½Oï¿½B
 --
 
 library ieee;
@@ -84,37 +84,43 @@ begin
     ----------------------------------------------------------------
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            ack <= '0';
-        elsif( clk21m'event and clk21m = '1' )then
-            if( wrt = '1' )then
-                ack <= req;
-            else
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
                 ack <= '0';
+	    else
+                if( wrt = '1' )then
+                    ack <= req;
+                else
+                    ack <= '0';
+                end if;
             end if;
         end if;
     end process;
 
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            kanjisel    <= '0';
-            updatereq   <= '0';
-        elsif( clk21m'event and clk21m = '1' )then
-            if( req = '1' and wrt = '0' and adr(0) = '1' )then
-                kanjisel    <= adr(1);
-                updatereq   <= not updateack;
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
+                kanjisel    <= '0';
+                updatereq   <= '0';
+	    else
+                if( req = '1' and wrt = '0' and adr(0) = '1' )then
+                    kanjisel    <= adr(1);
+                    updatereq   <= not updateack;
+                end if;
             end if;
         end if;
     end process;
 
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            updateack <= '0';
-        elsif( clk21m'event and clk21m = '1' )then
-            if( req = '0' and (updatereq /= updateack) )then
-                updateack <= not updateack;
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
+                updateack <= '0';
+	    else
+                if( req = '0' and (updatereq /= updateack) )then
+                    updateack <= not updateack;
+                end if;
             end if;
         end if;
     end process;
@@ -122,18 +128,20 @@ begin
     -- JIS1 decoding
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            kanjiptr1 <= (others => '0');
-        elsif( clk21m'event and clk21m = '1' )then
-            if( req = '1' and wrt = '1' and adr(1) = '0' )then
-                if( adr(0) = '0' )then
-                    kanjiptr1( 10 downto  5 ) <= dbo( 5 downto  0 );
-                else
-                    kanjiptr1( 16 downto 11 ) <= dbo( 5 downto  0 );
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
+                kanjiptr1 <= (others => '0');
+	    else
+                if( req = '1' and wrt = '1' and adr(1) = '0' )then
+                    if( adr(0) = '0' )then
+                        kanjiptr1( 10 downto  5 ) <= dbo( 5 downto  0 );
+                    else
+                        kanjiptr1( 16 downto 11 ) <= dbo( 5 downto  0 );
+                    end if;
+                    kanjiptr1(  4 downto  0 ) <= (others => '0');
+                elsif( req = '0' and (updatereq /= updateack) and kanjisel = '0' )then
+                    kanjiptr1(  4 downto  0 ) <= kanjiptr1( 4 downto  0 ) + 1;
                 end if;
-                kanjiptr1(  4 downto  0 ) <= (others => '0');
-            elsif( req = '0' and (updatereq /= updateack) and kanjisel = '0' )then
-                kanjiptr1(  4 downto  0 ) <= kanjiptr1( 4 downto  0 ) + 1;
             end if;
         end if;
     end process;
@@ -141,25 +149,27 @@ begin
     -- JIS2 decoding
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            kanjiptr2 <= (others => '0');
-        elsif( clk21m'event and clk21m = '1' )then
-            if( req = '1' and wrt = '1' and adr(1) = '1' )then
-                if( adr(0) = '0' )then
-                    kanjiptr2( 10 downto  5 ) <= dbo( 5 downto  0 );
-                else
-                    kanjiptr2( 16 downto 11 ) <= dbo( 5 downto  0 );
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
+                kanjiptr2 <= (others => '0');
+	    else
+                if( req = '1' and wrt = '1' and adr(1) = '1' )then
+                    if( adr(0) = '0' )then
+                        kanjiptr2( 10 downto  5 ) <= dbo( 5 downto  0 );
+                    else
+                        kanjiptr2( 16 downto 11 ) <= dbo( 5 downto  0 );
+                    end if;
+                    kanjiptr2(  4 downto  0 ) <= (others => '0');
+                elsif( req = '0' and (updatereq /= updateack) and kanjisel = '1' )then
+                    kanjiptr2(  4 downto  0 ) <= kanjiptr2( 4 downto  0 ) + 1;
                 end if;
-                kanjiptr2(  4 downto  0 ) <= (others => '0');
-            elsif( req = '0' and (updatereq /= updateack) and kanjisel = '1' )then
-                kanjiptr2(  4 downto  0 ) <= kanjiptr2( 4 downto  0 ) + 1;
             end if;
         end if;
     end process;
 
     process( clk21m )
     begin
-        if( clk21m'event and clk21m = '1' )then
+        if( rising_edge(clk21m) )then
             if( req = '0' and (updatereq /= updateack) )then
                 dbi <= ramdbi;
             end if;

--- a/peripheral/mapper.vhd
+++ b/peripheral/mapper.vhd
@@ -71,23 +71,27 @@ begin
 
   begin
 
-    if (reset = '1') then
+    if (rising_edge(clk21m)) then
 
-      MapBank0   <= X"03";
-      MapBank1   <= X"02";
-      MapBank2   <= X"01";
-      MapBank3   <= X"00";
+      if (reset = '1') then
 
-    elsif (clk21m'event and clk21m = '1') then
+        MapBank0   <= X"03";
+        MapBank1   <= X"02";
+        MapBank2   <= X"01";
+        MapBank3   <= X"00";
 
-      -- I/O port access on FC-FFh ... Mapper bank register write
-      if (req = '1' and mem = '0' and wrt = '1') then
-        case adr(1 downto 0) is
-          when "00"   => MapBank0 <= dbo;
-          when "01"   => MapBank1 <= dbo;
-          when "10"   => MapBank2 <= dbo;
-          when others => MapBank3 <= dbo;
-        end case;
+      else
+
+        -- I/O port access on FC-FFh ... Mapper bank register write
+        if (req = '1' and mem = '0' and wrt = '1') then
+          case adr(1 downto 0) is
+            when "00"   => MapBank0 <= dbo;
+            when "01"   => MapBank1 <= dbo;
+            when "10"   => MapBank2 <= dbo;
+            when others => MapBank3 <= dbo;
+          end case;
+        end if;
+
       end if;
 
     end if;

--- a/peripheral/megasd.vhd
+++ b/peripheral/megasd.vhd
@@ -85,27 +85,29 @@ begin
 
   begin
 
-    if (reset = '1') then
+    if (rising_edge(clk21m)) then
+        if (reset = '1') then
 
-      ErmBank0   <= X"00";
-      ErmBank1   <= X"00";
-      ErmBank2   <= X"00";
-      ErmBank3   <= X"00";
+          ErmBank0   <= X"00";
+          ErmBank1   <= X"00";
+          ErmBank2   <= X"00";
+          ErmBank3   <= X"00";
 
-    elsif (clk21m'event and clk21m = '1') then
+        else
 
-      -- Mapped I/O port access on 6000-7FFFh ... Bank register write
-      if (req = '1' and wrt = '1' and adr(15 downto 13) = "011") then
-        case adr(12 downto 11) is
-          when "00"   => ErmBank0 <= dbo;
-          when "01"   => ErmBank1 <= dbo;
-          when "10"   => ErmBank2 <= dbo;
-          when others => ErmBank3 <= dbo;
-        end case;
-      end if;
+          -- Mapped I/O port access on 6000-7FFFh ... Bank register write
+          if (req = '1' and wrt = '1' and adr(15 downto 13) = "011") then
+            case adr(12 downto 11) is
+              when "00"   => ErmBank0 <= dbo;
+              when "01"   => ErmBank1 <= dbo;
+              when "10"   => ErmBank2 <= dbo;
+              when others => ErmBank3 <= dbo;
+            end case;
+          end if;
 
-      ack <= req;
+          ack <= req;
 
+        end if;
     end if;
 
   end process;
@@ -138,125 +140,128 @@ begin
 
   begin
 
-    if (reset = '1') then
+    if (rising_edge(clk21m)) then
 
-      MmcEnx := '0';
-      EpcEna := '0';
-      MmcMod := (others => '0');
-      MmcSeq := (others => '0');
-      MmcTmp := (others => '1');
-      MmcDbo := (others => '1');
-      mmcdbi <= (others => '1');
+      if (reset = '1') then
 
-      mmc_ck <= '0';
-      mmc_cs <= '1';
-      mmc_di <= '0';
-      epc_ck <= '1';
-      epc_cs <= '1';
-      epc_di <= 'Z';
-
-    elsif (clk21m'event and clk21m = '1') then
-
-      if (ErmBank0(7 downto 6) = "01") then
-        MmcEnx := '1';
-      else
         MmcEnx := '0';
-      end if;
-
-      if (ErmBank0(7 downto 4) = "0110") then
-        EpcEna := '1';
-      else
         EpcEna := '0';
-      end if;
+        MmcMod := (others => '0');
+        MmcSeq := (others => '0');
+        MmcTmp := (others => '1');
+        MmcDbo := (others => '1');
+        mmcdbi <= (others => '1');
 
-      if (MmcSeq(0) = '0') then
-        case MmcSeq(4 downto 1) is
-          when "1001" => mmc_di <= MmcDbo(6); epc_di <= MmcDbo(6);
-          when "1000" => mmc_di <= MmcDbo(5); epc_di <= MmcDbo(5);
-          when "0111" => mmc_di <= MmcDbo(4); epc_di <= MmcDbo(4);
-          when "0110" => mmc_di <= MmcDbo(3); epc_di <= MmcDbo(3);
-          when "0101" => mmc_di <= MmcDbo(2); epc_di <= MmcDbo(2);
-          when "0100" => mmc_di <= MmcDbo(1); epc_di <= MmcDbo(1);
-          when "0011" => mmc_di <= MmcDbo(0); epc_di <= MmcDbo(0);
-          when "0010" => mmc_di <= '0';       epc_di <= '1';
-          when others => null;
-        end case;
-      end if;
+        mmc_ck <= '0';
+        mmc_cs <= '1';
+        mmc_di <= '0';
+        epc_ck <= '1';
+        epc_cs <= '1';
+        epc_di <= 'Z';
 
-      if (MmcSeq(0) = '1' and EpcEna = '0') then
-        case MmcSeq(4 downto 1) is
-          when "1001" => MmcTmp(7) := mmc_do;
-          when "1000" => MmcTmp(6) := mmc_do;
-          when "0111" => MmcTmp(5) := mmc_do;
-          when "0110" => MmcTmp(4) := mmc_do;
-          when "0101" => MmcTmp(3) := mmc_do;
-          when "0100" => MmcTmp(2) := mmc_do;
-          when "0011" => MmcTmp(1) := mmc_do;
-          when "0010" => MmcTmp(0) := mmc_do;
-          when "0001" => mmcdbi <= MmcTmp;
-          when others => null;
-        end case;
-      elsif (MmcSeq(0) = '1' and EpcEna = '1') then
-        case MmcSeq(4 downto 1) is
-          when "1001" => MmcTmp(7) := epc_do;
-          when "1000" => MmcTmp(6) := epc_do;
-          when "0111" => MmcTmp(5) := epc_do;
-          when "0110" => MmcTmp(4) := epc_do;
-          when "0101" => MmcTmp(3) := epc_do;
-          when "0100" => MmcTmp(2) := epc_do;
-          when "0011" => MmcTmp(1) := epc_do;
-          when "0010" => MmcTmp(0) := epc_do;
-          when "0001" => mmcdbi <= MmcTmp;
-          when others => null;
-        end case;
-      end if;
+      else
 
-      if (MmcSeq(4 downto 1) < "1011" and MmcSeq(4 downto 1) > "0001") then
-        if (EpcEna = '0') then
-          mmc_ck <= MmcSeq(0);
-          epc_ck <= '1';
+        if (ErmBank0(7 downto 6) = "01") then
+          MmcEnx := '1';
+        else
+          MmcEnx := '0';
+        end if;
+
+        if (ErmBank0(7 downto 4) = "0110") then
+          EpcEna := '1';
+        else
+          EpcEna := '0';
+        end if;
+
+        if (MmcSeq(0) = '0') then
+          case MmcSeq(4 downto 1) is
+            when "1001" => mmc_di <= MmcDbo(6); epc_di <= MmcDbo(6);
+            when "1000" => mmc_di <= MmcDbo(5); epc_di <= MmcDbo(5);
+            when "0111" => mmc_di <= MmcDbo(4); epc_di <= MmcDbo(4);
+            when "0110" => mmc_di <= MmcDbo(3); epc_di <= MmcDbo(3);
+            when "0101" => mmc_di <= MmcDbo(2); epc_di <= MmcDbo(2);
+            when "0100" => mmc_di <= MmcDbo(1); epc_di <= MmcDbo(1);
+            when "0011" => mmc_di <= MmcDbo(0); epc_di <= MmcDbo(0);
+            when "0010" => mmc_di <= '0';       epc_di <= '1';
+            when others => null;
+          end case;
+        end if;
+
+        if (MmcSeq(0) = '1' and EpcEna = '0') then
+          case MmcSeq(4 downto 1) is
+            when "1001" => MmcTmp(7) := mmc_do;
+            when "1000" => MmcTmp(6) := mmc_do;
+            when "0111" => MmcTmp(5) := mmc_do;
+            when "0110" => MmcTmp(4) := mmc_do;
+            when "0101" => MmcTmp(3) := mmc_do;
+            when "0100" => MmcTmp(2) := mmc_do;
+            when "0011" => MmcTmp(1) := mmc_do;
+            when "0010" => MmcTmp(0) := mmc_do;
+            when "0001" => mmcdbi <= MmcTmp;
+            when others => null;
+          end case;
+        elsif (MmcSeq(0) = '1' and EpcEna = '1') then
+          case MmcSeq(4 downto 1) is
+            when "1001" => MmcTmp(7) := epc_do;
+            when "1000" => MmcTmp(6) := epc_do;
+            when "0111" => MmcTmp(5) := epc_do;
+            when "0110" => MmcTmp(4) := epc_do;
+            when "0101" => MmcTmp(3) := epc_do;
+            when "0100" => MmcTmp(2) := epc_do;
+            when "0011" => MmcTmp(1) := epc_do;
+            when "0010" => MmcTmp(0) := epc_do;
+            when "0001" => mmcdbi <= MmcTmp;
+            when others => null;
+          end case;
+        end if;
+
+        if (MmcSeq(4 downto 1) < "1011" and MmcSeq(4 downto 1) > "0001") then
+          if (EpcEna = '0') then
+            mmc_ck <= MmcSeq(0);
+            epc_ck <= '1';
+          else
+            mmc_ck <= '0';
+            epc_ck <= MmcSeq(0);
+          end if;
         else
           mmc_ck <= '0';
-          epc_ck <= MmcSeq(0);
+          epc_ck <= '1';
         end if;
-      else
-        mmc_ck <= '0';
-        epc_ck <= '1';
-      end if;
 
-      -- Memory mapped I/O port access on 4000-57FFh ... SD/MMC data register
-      if (req = '1' and adr(15 downto 13) = "010" and adr(12 downto 11) /= "11" and
-          MmcEnx = '1' and MmcSeq = "00000" and MmcMod(0) = '0') then
-        if (wrt = '1') then
-          MmcDbo := dbo;
+        -- Memory mapped I/O port access on 4000-57FFh ... SD/MMC data register
+        if (req = '1' and adr(15 downto 13) = "010" and adr(12 downto 11) /= "11" and
+            MmcEnx = '1' and MmcSeq = "00000" and MmcMod(0) = '0') then
+          if (wrt = '1') then
+            MmcDbo := dbo;
+          else
+            MmcDbo := (others => '1');
+          end if;
+          if (EpcEna = '0') then
+            mmc_cs <= adr(12);
+            epc_cs <= '1';
+          else
+            mmc_cs <= '1';
+            epc_cs <= adr(12);
+          end if;
+          MmcSeq := "10011";
+          mmc_di <= MmcDbo(7);
+          	  epc_di <= MmcDbo(7);
+        elsif (MmcSeq /= "00000") then
+          MmcSeq := MmcSeq - 1;
+        end if;
+
+        -- Memory mapped I/O port access on 5800-5FFFh ... SD/MMC data register
+        if (req = '1' and adr(15 downto 13) = "010" and adr(12 downto 11)  = "11" and MmcEnx = '1' and wrt = '1') then
+          MmcMod := dbo(1 downto 0);
+        end if;
+
+        if (MmcSeq = "00000") then
+          mmcact <= '0';
         else
-          MmcDbo := (others => '1');
+          mmcact <= '1';
         end if;
-        if (EpcEna = '0') then
-          mmc_cs <= adr(12);
-          epc_cs <= '1';
-        else
-          mmc_cs <= '1';
-          epc_cs <= adr(12);
-        end if;
-        MmcSeq := "10011";
-        mmc_di <= MmcDbo(7);
-		  epc_di <= MmcDbo(7);
-      elsif (MmcSeq /= "00000") then
-        MmcSeq := MmcSeq - 1;
-      end if;
 
-      -- Memory mapped I/O port access on 5800-5FFFh ... SD/MMC data register
-      if (req = '1' and adr(15 downto 13) = "010" and adr(12 downto 11)  = "11" and MmcEnx = '1' and wrt = '1') then
-        MmcMod := dbo(1 downto 0);
       end if;
-
-      if (MmcSeq = "00000") then
-        mmcact <= '0';
-      else
-        mmcact <= '1';
-      end if;
-
     end if;
 
   end process;

--- a/peripheral/rtc.vhd
+++ b/peripheral/rtc.vhd
@@ -168,10 +168,12 @@ begin
     ----------------------------------------------------------------
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            ff_req <= '0';
-        elsif( clk21m'event and clk21m = '1' )then
-            ff_req <= req;
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
+                ff_req <= '0';
+	    else
+                ff_req <= req;
+            end if;
         end if;
     end process;
 
@@ -187,18 +189,20 @@ begin
     ----------------------------------------------------------------
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            ff_1sec_cnt <= "1001";
-        elsif( clk21m'event and clk21m = '1' )then
-            if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(1) = '1' and w_adr_dec(15) = '1' )then
-                -- reset register [cr bit]
-                if( dbo(1) = '1' )then
-                    ff_1sec_cnt <= "1001";
-                end if;
-            elsif( w_1sec = '1' )then
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
                 ff_1sec_cnt <= "1001";
-            elsif( w_enable = '1' )then
-                ff_1sec_cnt <= ff_1sec_cnt - 1;
+	    else
+                if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(1) = '1' and w_adr_dec(15) = '1' )then
+                    -- reset register [cr bit]
+                    if( dbo(1) = '1' )then
+                        ff_1sec_cnt <= "1001";
+                    end if;
+                elsif( w_1sec = '1' )then
+                    ff_1sec_cnt <= "1001";
+                elsif( w_enable = '1' )then
+                    ff_1sec_cnt <= ff_1sec_cnt - 1;
+                end if;
             end if;
         end if;
     end process;
@@ -211,7 +215,7 @@ begin
     ----------------------------------------------------------------
     process( clk21m )
     begin
-        if( clk21m'event and clk21m = '1' )then
+        if( rising_edge(clk21m) )then
             if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(0) = '1' and w_adr_dec( 0) = '1' )then
                 reg_sec_l <= dbo(3 downto 0);
             elsif( w_1sec = '1' )then
@@ -235,7 +239,7 @@ begin
     ----------------------------------------------------------------
     process( clk21m )
     begin
-        if( clk21m'event and clk21m = '1' )then
+        if( rising_edge(clk21m) )then
             if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(0) = '1' and w_adr_dec( 1) = '1' )then
                 reg_sec_h <= dbo(2 downto 0);
             elsif( (w_1sec and w_10sec) = '1' )then
@@ -259,7 +263,7 @@ begin
     ----------------------------------------------------------------
     process( clk21m )
     begin
-        if( clk21m'event and clk21m = '1' )then
+        if( rising_edge(clk21m) )then
             if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(0) = '1' and w_adr_dec( 2) = '1' )then
                 reg_min_l <= dbo(3 downto 0);
             elsif( (w_1sec and w_10sec and w_60sec) = '1' )then
@@ -283,7 +287,7 @@ begin
     ----------------------------------------------------------------
     process( clk21m )
     begin
-        if( clk21m'event and clk21m = '1' )then
+        if( rising_edge(clk21m) )then
             if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(0) = '1' and w_adr_dec( 3) = '1' )then
                 reg_min_h <= dbo(2 downto 0);
             elsif( (w_1sec and w_10sec and w_60sec and w_10min) = '1' )then
@@ -307,7 +311,7 @@ begin
     ----------------------------------------------------------------
     process( clk21m )
     begin
-        if( clk21m'event and clk21m = '1' )then
+        if( rising_edge(clk21m) )then
             if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(0) = '1' and w_adr_dec( 4) = '1' )then
                 reg_hou_l <= dbo(3 downto 0);
             elsif( (w_1sec and w_10sec and w_60sec and w_10min and w_60min) = '1' )then
@@ -325,7 +329,7 @@ begin
 
     process( clk21m )
     begin
-        if( clk21m'event and clk21m = '1' )then
+        if( rising_edge(clk21m) )then
             if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(0) = '1' and w_adr_dec( 5) = '1' )then
                 reg_hou_h <= dbo(1 downto 0);
             elsif( (w_1sec and w_10sec and w_60sec and w_10min and w_60min) = '1' )then
@@ -354,7 +358,7 @@ begin
     ----------------------------------------------------------------
     process( clk21m )
     begin
-        if( clk21m'event and clk21m = '1' )then
+        if( rising_edge(clk21m) )then
             if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(0) = '1' and w_adr_dec( 6) = '1' )then
                 reg_wee <= dbo(2 downto 0);
             elsif( (w_1sec and w_10sec and w_60sec and w_10min and w_60min and w_1224hour) = '1' )then
@@ -375,7 +379,7 @@ begin
     ----------------------------------------------------------------
     process( clk21m )
     begin
-        if( clk21m'event and clk21m = '1' )then
+        if( rising_edge(clk21m) )then
             if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(0) = '1' and w_adr_dec( 7) = '1' )then
                 reg_day_l <= dbo(3 downto 0);
             elsif( (w_1sec and w_10sec and w_60sec and w_10min and w_60min and w_1224hour) = '1' )then
@@ -401,7 +405,7 @@ begin
     ----------------------------------------------------------------
     process( clk21m )
     begin
-        if( clk21m'event and clk21m = '1' )then
+        if( rising_edge(clk21m) )then
             if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(0) = '1' and w_adr_dec( 8) = '1' )then
                 reg_day_h <= dbo(1 downto 0);
             elsif( (w_1sec and w_10sec and w_60sec and w_10min and w_60min and w_1224hour) = '1' )then
@@ -431,7 +435,7 @@ begin
     ----------------------------------------------------------------
     process( clk21m )
     begin
-        if( clk21m'event and clk21m = '1' )then
+        if( rising_edge(clk21m) )then
             if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(0) = '1' and w_adr_dec( 9) = '1' )then
                 reg_mon_l <= dbo(3 downto 0);
             elsif( (w_1sec and w_10sec and w_60sec and w_10min and w_60min and w_1224hour and w_next_mon) = '1' )then
@@ -457,7 +461,7 @@ begin
     ----------------------------------------------------------------
     process( clk21m )
     begin
-        if( clk21m'event and clk21m = '1' )then
+        if( rising_edge(clk21m) )then
             if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(0) = '1' and w_adr_dec(10) = '1' )then
                 reg_mon_h <= dbo(0);
             elsif( (w_1sec and w_10sec and w_60sec and w_10min and w_60min and w_1224hour and w_next_mon) = '1' )then
@@ -481,7 +485,7 @@ begin
     ----------------------------------------------------------------
     process( clk21m )
     begin
-        if( clk21m'event and clk21m = '1' )then
+        if( rising_edge(clk21m) )then
             if( w_wrt = '1' and adr(0) = '1' and w_bank_dec(0) = '1' and w_adr_dec(11) = '1' )then
                 reg_yea_l <= dbo(3 downto 0);
             elsif( (w_1sec and w_10sec and w_60sec and w_10min and w_60min and w_1224hour and w_next_mon and w_1year) = '1' )then
@@ -558,12 +562,14 @@ begin
     ----------------------------------------------------------------
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            reg_ptr <= (others => '0');
-        elsif( clk21m'event and clk21m = '1' )then
-            if( w_wrt = '1' and adr(0) = '0' )then
-                -- register pointer
-                reg_ptr <= dbo(3 downto 0);
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
+                reg_ptr <= (others => '0');
+	    else
+                if( w_wrt = '1' and adr(0) = '0' )then
+                    -- register pointer
+                    reg_ptr <= dbo(3 downto 0);
+                end if;
             end if;
         end if;
     end process;
@@ -573,11 +579,13 @@ begin
     ----------------------------------------------------------------
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            reg_mode        <= "1000";
-        elsif( clk21m'event and clk21m = '1' )then
-            if( w_wrt = '1' and adr(0) = '1' and w_adr_dec(13) = '1' )then
-                reg_mode <= dbo(3 downto 0);
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
+                reg_mode        <= "1000";
+	    else
+                if( w_wrt = '1' and adr(0) = '1' and w_adr_dec(13) = '1' )then
+                    reg_mode <= dbo(3 downto 0);
+                end if;
             end if;
         end if;
     end process;

--- a/peripheral/systemtimer.vhd
+++ b/peripheral/systemtimer.vhd
@@ -69,13 +69,15 @@ begin
 
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            ff_div_counter <=   (others => '0');
-        elsif( clk21m'event and clk21m = '1' )then
-            if( w_3_911usec = '1' )then
-                ff_div_counter <=   c_div_start_pt;
-            else
-                ff_div_counter <=   ff_div_counter - 1;
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
+                ff_div_counter <=   (others => '0');
+	    else
+                if( w_3_911usec = '1' )then
+                    ff_div_counter <=   c_div_start_pt;
+                else
+                    ff_div_counter <=   ff_div_counter - 1;
+                end if;
             end if;
         end if;
     end process;
@@ -85,13 +87,15 @@ begin
     ----------------------------------------------------------------
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            ff_freerun_counter <= (others => '0');
-        elsif( clk21m'event and clk21m = '1' )then
-            if( w_3_911usec = '1' )then
-                ff_freerun_counter <= ff_freerun_counter + 1;
-            else
-                -- hold
+        if( rising_edge(clk21m) )then
+            if( reset = '1' )then
+                ff_freerun_counter <= (others => '0');
+	    else
+                if( w_3_911usec = '1' )then
+                    ff_freerun_counter <= ff_freerun_counter + 1;
+                else
+                    -- hold
+                end if;
             end if;
         end if;
     end process;
@@ -101,10 +105,12 @@ begin
     ----------------------------------------------------------------
     process( reset, clk21m )
     begin
-        if( reset = '1' )then
-            ff_ack <= '0';
-        elsif( clk21m'event and clk21m = '1' )then
-            ff_ack <= req;
+        if( clk21m'event and clk21m = '1' )then
+            if( reset = '1' )then
+                ff_ack <= '0';
+	    else
+                ff_ack <= req;
+            end if;
         end if;
     end process;
 end rtl;


### PR DESCRIPTION
This silences 1 of the 2 remaining async clock warnings in Quartus!

Also attempts to cherry pick small changes to vdp_vga.vhd from OCM-PLD v3.7.1. If I made a mistake there can revert. Also not sure how useful the 1:1 ratiomode is for MiSTer but I figured I'd bring it over in case.