### PR TITLE
Add an option to the menu to automatically RESET the core after mounting a VHD image

### DIFF
--- a/MSX.sv
+++ b/MSX.sv
@@ -135,6 +135,7 @@ localparam CONF_STR = {
 	"MSX;;",
 	"-;",
 	"S,VHD;",
+	"OE,Reset after Mount,No,Yes;",
 	"-;",
 	"O9,Aspect ratio,4:3,16:9;",
 	"O23,Scanlines,No,25%,50%,75%;",
@@ -173,7 +174,7 @@ pll pll
 );
 
 wire cold_reset = RESET | status[0] | ~initReset_n;
-wire reset = cold_reset | buttons[1] | status[10];
+wire reset = cold_reset | buttons[1] | status[10] | (status[14] && img_mounted);
 
 reg initReset_n = 0;
 always @(posedge clk_sys) begin


### PR DESCRIPTION
Hi,

this pull request implements the feature discussed in #11. As a recap:

- If the new option "Reset after Mount" is set to **No** (default), the behavior of the core is unchanged.
- If the option is set to **Yes** the core will reset when the mounted image is changed from the menu. This allows [autobootable images](https://github.com/nilp0inter/msxrom2vhd) to be loaded more easily, giving a similar user experience as with ROM cartridges.

I tested it over 20190712 and is working fine. 
I had problems running *master* (even without my patch), so I cannot test it there.