### PR TITLE
Adjust OPLL i_ACC_SIGNED_ROVOL to balance melody and rhythm volume

### DIFF
--- a/rtl/SOUND/OPLL/eseopll_ikaopll.vhd
+++ b/rtl/SOUND/OPLL/eseopll_ikaopll.vhd
@@ -160,7 +160,7 @@ begin
       o_IMP_FLUC_SIGNED_MO => open,
       o_IMP_FLUC_SIGNED_RO => open,
       i_ACC_SIGNED_MOVOL   => to_signed(4, 5),
-      i_ACC_SIGNED_ROVOL   => to_signed(5, 5),
+      i_ACC_SIGNED_ROVOL   => to_signed(9, 5),
       o_ACC_SIGNED_STRB    => open,
       o_ACC_SIGNED         => wav16
     );


### PR DESCRIPTION
The melody and rhythm instrument levels of OPLL were tuned to better match real hardware through direct comparison.